### PR TITLE
Fix QUIET mode

### DIFF
--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -364,13 +364,13 @@ ClimateTraits ToshibaClimateUart::traits() {
   traits.set_supports_current_temperature(true);
 
   traits.add_supported_fan_mode(CLIMATE_FAN_AUTO);
+  traits.add_supported_fan_mode(CUSTOM_FAN_LEVEL_QUIET);
   // Toshiba AC has more FAN levels that standard climate component, we have to use custom.
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_1);
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_2);
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_3);
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_4);
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_5);
-  traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_QUIET);
 
   traits.set_visual_temperature_step(1);
   traits.set_visual_min_temperature(MIN_TEMP);

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -221,6 +221,9 @@ void ToshibaClimateUart::parseResponse(std::vector<uint8_t> rawData) {
       if (static_cast<FAN>(value) == FAN::AUTO) {
         ESP_LOGI(TAG, "Received fan mode: AUTO");
         this->set_fan_mode_(CLIMATE_FAN_AUTO);
+      } else if (static_cast<FAN>(value) == FAN::QUIET) {
+        ESP_LOGI(TAG, "Received fan mode: QUIET");
+        this->set_fan_mode_(CLIMATE_FAN_QUIET);
       } else {
         auto fanMode = IntToCustomFanMode(static_cast<FAN>(value));
         ESP_LOGI(TAG, "Received fan mode: %s", fanMode.c_str());
@@ -332,6 +335,10 @@ void ToshibaClimateUart::control(const climate::ClimateCall &call) {
       ESP_LOGD(TAG, "Setting fan mode to %s", climate_fan_mode_to_string(fan_mode));
       this->set_fan_mode_(fan_mode);
       this->sendCmd(ToshibaCommandType::FAN, static_cast<uint8_t>(FAN::AUTO));
+    } else if (fan_mode == CLIMATE_FAN_QUIET) {
+      ESP_LOGD(TAG, "Setting fan mode to %s", climate_fan_mode_to_string(fan_mode));
+      this->set_fan_mode_(fan_mode);
+      this->sendCmd(ToshibaCommandType::FAN, static_cast<uint8_t>(FAN::QUIET));
     }
   }
 
@@ -364,7 +371,7 @@ ClimateTraits ToshibaClimateUart::traits() {
   traits.set_supports_current_temperature(true);
 
   traits.add_supported_fan_mode(CLIMATE_FAN_AUTO);
-  traits.add_supported_fan_mode(CUSTOM_FAN_LEVEL_QUIET);
+  traits.add_supported_fan_mode(CLIMATE_FAN_QUIET);
   // Toshiba AC has more FAN levels that standard climate component, we have to use custom.
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_1);
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_2);

--- a/components/toshiba_suzumi/toshiba_climate_mode.cpp
+++ b/components/toshiba_suzumi/toshiba_climate_mode.cpp
@@ -43,9 +43,7 @@ const climate::ClimateMode IntToClimateMode(MODE mode) {
 }
 
 const optional<FAN> StringToFanLevel(std::string mode) {
-  if (mode == CUSTOM_FAN_LEVEL_QUIET) {
-    return FAN::QUIET;
-  } else if (mode == CUSTOM_FAN_LEVEL_1) {
+  if (mode == CUSTOM_FAN_LEVEL_1) {
     return FAN::FANMODE_1;
   } else if (mode == CUSTOM_FAN_LEVEL_2) {
     return FAN::FANMODE_2;
@@ -62,8 +60,6 @@ const optional<FAN> StringToFanLevel(std::string mode) {
 
 const std::string IntToCustomFanMode(FAN mode) {
   switch (mode) {
-    case FAN::QUIET:
-      return CUSTOM_FAN_LEVEL_QUIET;
     case FAN::FANMODE_1:
       return CUSTOM_FAN_LEVEL_1;
     case FAN::FANMODE_2:

--- a/components/toshiba_suzumi/toshiba_climate_mode.h
+++ b/components/toshiba_suzumi/toshiba_climate_mode.h
@@ -7,7 +7,6 @@
 namespace esphome {
 namespace toshiba_suzumi {
 
-static const std::string CUSTOM_FAN_LEVEL_QUIET = "Quiet";
 static const std::string CUSTOM_FAN_LEVEL_1 = "Level 1";
 static const std::string CUSTOM_FAN_LEVEL_2 = "Level 2";
 static const std::string CUSTOM_FAN_LEVEL_3 = "Level 3";


### PR DESCRIPTION
I have a Toshiba RAS-18TKVG-EE air conditioner, component works great with esp8266.

But when I try to switch the fan mode to "Quiet", I get a "Mode QUIET is not supported by this device!" error.

This is most likely due to the fact that the quiet mode is defined as custom_fan_mode, but 'quiet' exists in the fan_mode.

With this fix everything works