### PR TITLE
Added WIFI Status led disabling during startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ climate:
         #- "Fireplace 2" 
         #- "8 degrees"
         #- "Silent#1" 
-        #- "Silent#2"    
+        #- "Silent#2"
+    #disable_wifi_led: true # Optional. Disable Wifi LED on internal unit.
 ...
 ```
 

--- a/components/toshiba_suzumi/climate.py
+++ b/components/toshiba_suzumi/climate.py
@@ -18,6 +18,7 @@ CONF_SPECIAL_MODE = "special_mode"
 CONF_SPECIAL_MODE_MODES = "modes"
 
 FEATURE_HORIZONTAL_SWING = "horizontal_swing"
+DISABLE_WIFI_LED = "disable_wifi_led"
 
 toshiba_ns = cg.esphome_ns.namespace("toshiba_suzumi")
 ToshibaClimateUart = toshiba_ns.class_("ToshibaClimateUart", cg.PollingComponent, climate.Climate, uart.UARTDevice)
@@ -37,6 +38,7 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
             cv.GenerateID(): cv.declare_id(ToshibaPwrModeSelect),
         }),
         cv.Optional(FEATURE_HORIZONTAL_SWING): cv.boolean,
+        cv.Optional(DISABLE_WIFI_LED): cv.boolean,
         cv.Optional(CONF_SPECIAL_MODE): select.SELECT_SCHEMA.extend({
             cv.GenerateID(): cv.declare_id(ToshibaSpecialModeSelect),
             cv.Required(CONF_SPECIAL_MODE_MODES): cv.ensure_list(cv.one_of("Standard","Hi POWER","ECO","Fireplace 1","Fireplace 2","8 degrees", "Silent#1","Silent#2"))
@@ -62,6 +64,9 @@ async def to_code(config):
 
     if FEATURE_HORIZONTAL_SWING in config:
         cg.add(var.set_horizontal_swing(True))
+
+    if DISABLE_WIFI_LED in config:
+        cg.add(var.disable_wifi_led(True))
 
     if CONF_SPECIAL_MODE in config:
         sel = await select.new_select(config[CONF_SPECIAL_MODE], options=config[CONF_SPECIAL_MODE][CONF_SPECIAL_MODE_MODES])

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -144,6 +144,8 @@ void ToshibaClimateUart::setup() {
   this->start_handshake();
   // load initial sensor data from the unit
   this->getInitData();
+  // Disable Wifi LED
+  this->sendCmd(ToshibaCommandType::WIFI_LED, 128);
 }
 
 /**
@@ -306,7 +308,7 @@ void ToshibaClimateUart::dump_config() {
   }
   if (special_mode_select_ != nullptr) {
     LOG_SELECT("", "Special mode selector", this->special_mode_select_);
-  } 
+  }
 }
 
 /**

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -144,8 +144,11 @@ void ToshibaClimateUart::setup() {
   this->start_handshake();
   // load initial sensor data from the unit
   this->getInitData();
-  // Disable Wifi LED
-  this->sendCmd(ToshibaCommandType::WIFI_LED, 128);
+
+  if (this->wifi_led_disabled_) {
+    // Disable Wifi LED
+    this->sendCmd(ToshibaCommandType::WIFI_LED, 128);
+  }
 }
 
 /**

--- a/components/toshiba_suzumi/toshiba_climate.h
+++ b/components/toshiba_suzumi/toshiba_climate.h
@@ -42,6 +42,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void set_outdoor_temp_sensor(sensor::Sensor *outdoor_temp_sensor) { outdoor_temp_sensor_ = outdoor_temp_sensor; }
   void set_pwr_select(select::Select *pws_select) { pwr_select_ = pws_select; }
   void set_horizontal_swing(bool enabled) { horizontal_swing_ = enabled; }
+  void disable_wifi_led(bool disabled) { wifi_led_disabled_ = disabled; }
   void set_special_mode_select(select::Select *special_mode_select) { special_mode_select_ = special_mode_select; }
 
  protected:
@@ -60,6 +61,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   select::Select *pwr_select_ = nullptr;
   sensor::Sensor *outdoor_temp_sensor_ = nullptr;
   bool horizontal_swing_ = false;
+  bool wifi_led_disabled_ = false;
   select::Select *special_mode_select_ = nullptr;
 
   void enqueue_command_(const ToshibaCommand &command);

--- a/components/toshiba_suzumi/toshiba_climate_mode.h
+++ b/components/toshiba_suzumi/toshiba_climate_mode.h
@@ -25,8 +25,8 @@ static const std::string &SPECIAL_MODE_ECO = "ECO";
 static const std::string &SPECIAL_MODE_FIREPLACE_1 = "Fireplace 1";
 static const std::string &SPECIAL_MODE_FIREPLACE_2 = "Fireplace 2";
 static const std::string &SPECIAL_MODE_EIGHT_DEG = "8 degrees";
-static const std::string &SPECIAL_MODE_SILENT_1 = "Silent#1"; 
-static const std::string &SPECIAL_MODE_SILENT_2 = "Silent#2"; 
+static const std::string &SPECIAL_MODE_SILENT_1 = "Silent#1";
+static const std::string &SPECIAL_MODE_SILENT_2 = "Silent#2";
 
 enum class CustomFanModes { QUIET, LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4, LEVEL_5, AUTO };
 
@@ -52,7 +52,7 @@ enum SPECIAL_MODE {
   FIREPLACE_1 = 32,
   FIREPLACE_2 = 48,
   EIGHT_DEG = 4,
-  SILENT_1 = 2, 
+  SILENT_1 = 2,
   SILENT_2 = 10
 };
 
@@ -68,6 +68,7 @@ enum class ToshibaCommandType : uint8_t {
   TARGET_TEMP = 179,
   ROOM_TEMP = 187,
   OUTDOOR_TEMP = 190,
+  WIFI_LED = 223,
   SPECIAL_MODE = 247,
 };
 

--- a/example.yaml
+++ b/example.yaml
@@ -43,6 +43,7 @@ climate:
         #- "Hi POWER"
         #- "8 degrees"
         #- "Fireplace"
+    #disable_wifi_led: true # Optional. Disable Wifi LED on internal unit.
 
 # Enable button to scan for unknown values in AC unit. This is optional.
 button:

--- a/example_esp8266.yaml
+++ b/example_esp8266.yaml
@@ -40,6 +40,7 @@ climate:
         #- "Hi POWER"
         #- "8 degrees"
         #- "Fireplace"
+    #disable_wifi_led: true # Optional. Disable Wifi LED on internal unit.
 
 # Enable button to scan for unknown values in AC unit. This is optional.
 button:


### PR DESCRIPTION
Hi,
I have Wifi indicator led on my splits. I can disable it with thoshiba's original wifi product, but not with this esphome integration.
I managed to find the wifi led command number using the scan command, and the value disabling the led.

Here is a pull request adding a sendCmd to the init process disabling this hell-its-like-plain-day led !

Keep in mind I'm not a C++ developer, not an esphome or toshiba expert, so feel free to change everything you think is bad.

Sorry for the lint, my IDE removed trailing spaces in the modified files !

Regards,