### PR TITLE
Fix min_temp configuration processing

### DIFF
--- a/components/toshiba_suzumi/climate.py
+++ b/components/toshiba_suzumi/climate.py
@@ -68,7 +68,7 @@ async def to_code(config):
         cg.add(var.set_horizontal_swing(True))
 
     if MIN_TEMP in config:
-        var = cg.add(var.set_min_temp(config[MIN_TEMP]))
+        cg.add(var.set_min_temp(config[MIN_TEMP]))
 
     if DISABLE_WIFI_LED in config:
         cg.add(var.disable_wifi_led(True))


### PR DESCRIPTION
Hi,
I Fixed a variable overwrite in climate.py preventing compilation when min_temp is set.

It's a really simple fix, but I think it can be very usefull as the bug prevent use of the min_temp option !

Regards,