### PR TITLE
[breaking change] Combine supported fan modes & custom fan modes

### DIFF
--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -226,12 +226,21 @@ void ToshibaClimateUart::parseResponse(std::vector<uint8_t> rawData) {
       this->target_temperature = value;
       break;
     case ToshibaCommandType::FAN: {
-      if (static_cast<FAN>(value) == FAN::AUTO) {
+      if (static_cast<FAN>(value) == FAN::FAN_AUTO) {
         ESP_LOGI(TAG, "Received fan mode: AUTO");
         this->set_fan_mode_(CLIMATE_FAN_AUTO);
-      } else if (static_cast<FAN>(value) == FAN::QUIET) {
+      } else if (static_cast<FAN>(value) == FAN::FAN_QUIET) {
         ESP_LOGI(TAG, "Received fan mode: QUIET");
         this->set_fan_mode_(CLIMATE_FAN_QUIET);
+      } else if (static_cast<FAN>(value) == FAN::FAN_LOW) {
+        ESP_LOGI(TAG, "Received fan mode: LOW");
+        this->set_fan_mode_(CLIMATE_FAN_LOW);
+      } else if (static_cast<FAN>(value) == FAN::FAN_MEDIUM) {
+        ESP_LOGI(TAG, "Received fan mode: MEDIUM");
+        this->set_fan_mode_(CLIMATE_FAN_MEDIUM);
+      } else if (static_cast<FAN>(value) == FAN::FAN_HIGH) {
+        ESP_LOGI(TAG, "Received fan mode: HIGH");
+        this->set_fan_mode_(CLIMATE_FAN_HIGH);
       } else {
         auto fanMode = IntToCustomFanMode(static_cast<FAN>(value));
         ESP_LOGI(TAG, "Received fan mode: %s", fanMode.c_str());
@@ -354,15 +363,29 @@ void ToshibaClimateUart::control(const climate::ClimateCall &call) {
   }
 
   if (call.get_fan_mode().has_value()) {
+
+
     auto fan_mode = *call.get_fan_mode();
     if (fan_mode == CLIMATE_FAN_AUTO) {
       ESP_LOGD(TAG, "Setting fan mode to %s", climate_fan_mode_to_string(fan_mode));
       this->set_fan_mode_(fan_mode);
-      this->sendCmd(ToshibaCommandType::FAN, static_cast<uint8_t>(FAN::AUTO));
+      this->sendCmd(ToshibaCommandType::FAN, static_cast<uint8_t>(FAN::FAN_AUTO));
     } else if (fan_mode == CLIMATE_FAN_QUIET) {
       ESP_LOGD(TAG, "Setting fan mode to %s", climate_fan_mode_to_string(fan_mode));
       this->set_fan_mode_(fan_mode);
-      this->sendCmd(ToshibaCommandType::FAN, static_cast<uint8_t>(FAN::QUIET));
+      this->sendCmd(ToshibaCommandType::FAN, static_cast<uint8_t>(FAN::FAN_QUIET));
+    } else if (fan_mode == CLIMATE_FAN_LOW) {
+      ESP_LOGD(TAG, "Setting fan mode to %s", climate_fan_mode_to_string(fan_mode));
+      this->set_fan_mode_(fan_mode);
+      this->sendCmd(ToshibaCommandType::FAN, static_cast<uint8_t>(FAN::FAN_LOW));
+    } else if (fan_mode == CLIMATE_FAN_MEDIUM) {
+      ESP_LOGD(TAG, "Setting fan mode to %s", climate_fan_mode_to_string(fan_mode));
+      this->set_fan_mode_(fan_mode);
+      this->sendCmd(ToshibaCommandType::FAN, static_cast<uint8_t>(FAN::FAN_MEDIUM));
+    } else if (fan_mode == CLIMATE_FAN_HIGH) {
+      ESP_LOGD(TAG, "Setting fan mode to %s", climate_fan_mode_to_string(fan_mode));
+      this->set_fan_mode_(fan_mode);
+      this->sendCmd(ToshibaCommandType::FAN, static_cast<uint8_t>(FAN::FAN_HIGH));
     }
   }
 
@@ -401,12 +424,12 @@ ClimateTraits ToshibaClimateUart::traits() {
 
   traits.add_supported_fan_mode(CLIMATE_FAN_AUTO);
   traits.add_supported_fan_mode(CLIMATE_FAN_QUIET);
+  traits.add_supported_fan_mode(CLIMATE_FAN_LOW);
+  traits.add_supported_fan_mode(CLIMATE_FAN_MEDIUM);
+  traits.add_supported_fan_mode(CLIMATE_FAN_HIGH);
   // Toshiba AC has more FAN levels that standard climate component, we have to use custom.
-  traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_1);
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_2);
-  traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_3);
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_4);
-  traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_5);
 
   traits.set_visual_temperature_step(1);
   traits.set_visual_min_temperature(this->min_temp_);

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -422,14 +422,14 @@ ClimateTraits ToshibaClimateUart::traits() {
   }
   traits.set_supports_current_temperature(true);
 
+  // Toshiba AC has more FAN levels that standard climate component, we have to use custom.
   traits.add_supported_fan_mode(CLIMATE_FAN_AUTO);
   traits.add_supported_fan_mode(CLIMATE_FAN_QUIET);
   traits.add_supported_fan_mode(CLIMATE_FAN_LOW);
-  traits.add_supported_fan_mode(CLIMATE_FAN_MEDIUM);
-  traits.add_supported_fan_mode(CLIMATE_FAN_HIGH);
-  // Toshiba AC has more FAN levels that standard climate component, we have to use custom.
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_2);
+  traits.add_supported_fan_mode(CLIMATE_FAN_MEDIUM);
   traits.add_supported_custom_fan_mode(CUSTOM_FAN_LEVEL_4);
+  traits.add_supported_fan_mode(CLIMATE_FAN_HIGH);
 
   traits.set_visual_temperature_step(1);
   traits.set_visual_min_temperature(this->min_temp_);

--- a/components/toshiba_suzumi/toshiba_climate_mode.cpp
+++ b/components/toshiba_suzumi/toshiba_climate_mode.cpp
@@ -43,16 +43,10 @@ const climate::ClimateMode IntToClimateMode(MODE mode) {
 }
 
 const optional<FAN> StringToFanLevel(std::string mode) {
-  if (mode == CUSTOM_FAN_LEVEL_1) {
-    return FAN::FANMODE_1;
-  } else if (mode == CUSTOM_FAN_LEVEL_2) {
+  if (mode == CUSTOM_FAN_LEVEL_2) {
     return FAN::FANMODE_2;
-  } else if (mode == CUSTOM_FAN_LEVEL_3) {
-    return FAN::FANMODE_3;
   } else if (mode == CUSTOM_FAN_LEVEL_4) {
     return FAN::FANMODE_4;
-  } else if (mode == CUSTOM_FAN_LEVEL_5) {
-    return FAN::FANMODE_5;
   } else {
     return nullopt;
   }
@@ -60,16 +54,10 @@ const optional<FAN> StringToFanLevel(std::string mode) {
 
 const std::string IntToCustomFanMode(FAN mode) {
   switch (mode) {
-    case FAN::FANMODE_1:
-      return CUSTOM_FAN_LEVEL_1;
     case FAN::FANMODE_2:
       return CUSTOM_FAN_LEVEL_2;
-    case FAN::FANMODE_3:
-      return CUSTOM_FAN_LEVEL_3;
     case FAN::FANMODE_4:
       return CUSTOM_FAN_LEVEL_4;
-    case FAN::FANMODE_5:
-      return CUSTOM_FAN_LEVEL_5;
     default:
       return "Unknown";
   }

--- a/components/toshiba_suzumi/toshiba_climate_mode.h
+++ b/components/toshiba_suzumi/toshiba_climate_mode.h
@@ -7,11 +7,8 @@
 namespace esphome {
 namespace toshiba_suzumi {
 
-static const std::string &CUSTOM_FAN_LEVEL_1 = "Level 1";
-static const std::string &CUSTOM_FAN_LEVEL_2 = "Level 2";
-static const std::string &CUSTOM_FAN_LEVEL_3 = "Level 3";
-static const std::string &CUSTOM_FAN_LEVEL_4 = "Level 4";
-static const std::string &CUSTOM_FAN_LEVEL_5 = "Level 5";
+static const std::string &CUSTOM_FAN_LEVEL_2 = "Low-Medium";
+static const std::string &CUSTOM_FAN_LEVEL_4 = "Medium-High";
 
 static const std::string &CUSTOM_PWR_LEVEL_50 = "50 %";
 static const std::string &CUSTOM_PWR_LEVEL_75 = "75 %";
@@ -28,18 +25,16 @@ static const std::string &SPECIAL_MODE_EIGHT_DEG = "8 degrees";
 static const std::string &SPECIAL_MODE_SILENT_1 = "Silent#1";
 static const std::string &SPECIAL_MODE_SILENT_2 = "Silent#2";
 
-enum class CustomFanModes { QUIET, LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4, LEVEL_5, AUTO };
-
 // codes as reverse engineered from Toshiba AC communication with original Wifi module.
 enum class MODE { HEAT_COOL = 65, COOL = 66, HEAT = 67, DRY = 68, FAN_ONLY = 69 };
 enum class FAN {
-  QUIET = 49,
-  FANMODE_1 = 50,
+  FAN_QUIET = 49,
+  FAN_LOW = 50,
   FANMODE_2 = 51,
-  FANMODE_3 = 52,
+  FAN_MEDIUM = 52,
   FANMODE_4 = 53,
-  FANMODE_5 = 54,
-  AUTO = 65
+  FAN_HIGH = 54,
+  FAN_AUTO = 65
 };
 enum class SWING { OFF = 49, BOTH =  67, VERTICAL = 65, HORIZONTAL = 66 };
 enum class STATE { ON = 48, OFF = 49 };


### PR DESCRIPTION
This PR allow the integration to have more "supported fan modes". This allow other integrations to use those fan modes.
For example versatile thermostat can use supported fan modes when the AC don't see the right temperature, to mix air.

I had some conflicts in the process, so I renamed some enum values.

WARNING ! It's a breaking change for people using fan speed in automations !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced fan mode support with new standard fan levels: Low, Medium, and High
  - Improved fan mode naming for better clarity

- **Improvements**
  - Simplified fan level handling
  - Updated fan mode constants to provide more descriptive labels

- **Changes**
  - Removed some custom fan levels
  - Renamed existing fan mode constants for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->