### PR TITLE
Update example_esp8266.yaml

### DIFF
--- a/example_esp8266.yaml
+++ b/example_esp8266.yaml
@@ -15,7 +15,7 @@ logger:
 uart:
   id: uart_bus
   tx_pin: 13
-  rx_pin: 15
+  rx_pin: 12
   parity: EVEN
   baud_rate: 9600
 


### PR DESCRIPTION
use by default GPIO12 for RX