### PR TITLE
Fix Wi-Fi LED support and expose the LED control to set_wifi_led(bool)

### DIFF
--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -144,11 +144,8 @@ void ToshibaClimateUart::setup() {
   this->start_handshake();
   // load initial sensor data from the unit
   this->getInitData();
-
-  if (this->wifi_led_disabled_) {
-    // Disable Wifi LED
-    this->sendCmd(ToshibaCommandType::WIFI_LED, 128);
-  }
+  // Set Wi-Fi LED initial state
+  this->set_wifi_led(!this->wifi_led_disabled_);
 }
 
 /**
@@ -582,6 +579,21 @@ void ToshibaClimateUart::scan() {
   ESP_LOGI(TAG, "Scan started.");
   for (uint8_t i = 128; i < 255; i++) {
     this->requestData(static_cast<ToshibaCommandType>(i));
+  }
+}
+
+/**
+ * Expose Wi-Fi LED control
+ */
+void ToshibaClimateUart::set_wifi_led(bool enabled) {
+  if (enabled) {
+    ESP_LOGI(TAG, "Turning ON Wi-Fi LED");
+    this->sendCmd(ToshibaCommandType::WIFI_LED_1, 0x05);
+    this->sendCmd(ToshibaCommandType::WIFI_LED_2, 0x00);
+  } else {
+    ESP_LOGI(TAG, "Turning OFF Wi-Fi LED");
+    this->sendCmd(ToshibaCommandType::WIFI_LED_1, 0x00);
+    this->sendCmd(ToshibaCommandType::WIFI_LED_2, 0x80);
   }
 }
 

--- a/components/toshiba_suzumi/toshiba_climate.h
+++ b/components/toshiba_suzumi/toshiba_climate.h
@@ -44,6 +44,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void dump_config() override;
   void update() override;
   void scan();
+  void set_wifi_led(bool enabled);
   float get_setup_priority() const override { return setup_priority::LATE; }
 
   void set_outdoor_temp_sensor(sensor::Sensor *outdoor_temp_sensor) { outdoor_temp_sensor_ = outdoor_temp_sensor; }

--- a/components/toshiba_suzumi/toshiba_climate_mode.h
+++ b/components/toshiba_suzumi/toshiba_climate_mode.h
@@ -69,7 +69,8 @@ enum class ToshibaCommandType : uint8_t {
   TARGET_TEMP = 179,
   ROOM_TEMP = 187,
   OUTDOOR_TEMP = 190,
-  WIFI_LED = 223,
+  WIFI_LED_1 = 222,
+  WIFI_LED_2 = 223,
   SPECIAL_MODE = 247,
 };
 


### PR DESCRIPTION
# Summary

This PR implements two changes:

1. Fixes Wi-Fi LED support for devices using code 222 instead of 223. The PR now triggers both codes when toggling Wi-Fi.

2. Moves Wi-Fi LED control to a dedicated `ToshibaClimateUart::set_wifi_led` function. This allows for direct lambda calls from ESPHome and internal use within the component.

Note: The startup behavior of the Wi-Fi LED remains unchanged, adhering to the user's `disable_wifi_led` configuration.

# Examples

## Direct lambda calls from ESPHome

Using `living_room` as the Air Conditioner ID, similar to the example in README.md:

```yaml
switch:
  - platform: template
    name: WiFi LED
    id: wifi_led
    optimistic: true
    turn_on_action:
      - lambda: |-
          auto* controller = static_cast<toshiba_suzumi::ToshibaClimateUart*>(id(living_room));
          controller->set_wifi_led(true);
    turn_off_action:
      - lambda: |-
          auto* controller = static_cast<toshiba_suzumi::ToshibaClimateUart*>(id(living_room));
          controller->set_wifi_led(false);
    entity_category: config
```

<img width="324" height="81" alt="image" src="https://github.com/user-attachments/assets/e16005e3-8e60-4bca-a49f-d3946f928f25" />

Also Fix #21
