### PR TITLE
Add dedicated entity for Indoor Temperature sensor

### DIFF
--- a/components/toshiba_suzumi/climate.py
+++ b/components/toshiba_suzumi/climate.py
@@ -20,6 +20,7 @@ DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["sensor", "select"]
 
 CONF_ROOM_TEMP = "room_temp"
+CONF_INDOOR_TEMP = "indoor_temp"
 CONF_OUTDOOR_TEMP = "outdoor_temp"
 CONF_CDU_TD_TEMP = "cdu_td_temp"
 CONF_CDU_TS_TEMP = "cdu_ts_temp"
@@ -47,6 +48,12 @@ ToshibaSpecialModeSelect = toshiba_ns.class_('ToshibaSpecialModeSelect', select.
 CONFIG_SCHEMA = climate.climate_schema(ToshibaClimateUart).extend(
     {
         cv.GenerateID(): cv.declare_id(ToshibaClimateUart),
+        cv.Optional(CONF_INDOOR_TEMP): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
         cv.Optional(CONF_OUTDOOR_TEMP): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=0,
@@ -121,6 +128,11 @@ async def to_code(config):
     await cg.register_component(var, config)
     await climate.register_climate(var, config)
     await uart.register_uart_device(var, config)
+
+    if CONF_INDOOR_TEMP in config:
+        conf = config[CONF_INDOOR_TEMP]
+        sens = await sensor.new_sensor(conf)
+        cg.add(var.set_indoor_temp_sensor(sens))
 
     if CONF_OUTDOOR_TEMP in config:
         conf = config[CONF_OUTDOOR_TEMP]

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -282,6 +282,9 @@ void ToshibaClimateUart::parseResponse(std::vector<uint8_t> rawData) {
     case ToshibaCommandType::ROOM_TEMP:
       ESP_LOGI(TAG, "Received room temp: %d °C", value);
       this->current_temperature = value;
+      if (indoor_temp_sensor_ != nullptr) {
+        indoor_temp_sensor_->publish_state((int8_t) value);
+      }
       break;
     case ToshibaCommandType::OUTDOOR_TEMP:
       if (outdoor_temp_sensor_ != nullptr) {

--- a/components/toshiba_suzumi/toshiba_climate.h
+++ b/components/toshiba_suzumi/toshiba_climate.h
@@ -47,6 +47,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void set_wifi_led(bool enabled);
   float get_setup_priority() const override { return setup_priority::LATE; }
 
+  void set_indoor_temp_sensor(sensor::Sensor *indoor_temp_sensor) { indoor_temp_sensor_ = indoor_temp_sensor; }
   void set_outdoor_temp_sensor(sensor::Sensor *outdoor_temp_sensor) { outdoor_temp_sensor_ = outdoor_temp_sensor; }
   void set_cdu_td_temp_sensor(sensor::Sensor *sensor) { cdu_td_temp_sensor_ = sensor; }
   void set_cdu_ts_temp_sensor(sensor::Sensor *sensor) { cdu_ts_temp_sensor_ = sensor; }
@@ -78,6 +79,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   STATE power_state_ = STATE::OFF;
   optional<SPECIAL_MODE> special_mode_ = SPECIAL_MODE::STANDARD;
   select::Select *pwr_select_ = nullptr;
+  sensor::Sensor *indoor_temp_sensor_ = nullptr;
   sensor::Sensor *outdoor_temp_sensor_ = nullptr;
   sensor::Sensor *cdu_td_temp_sensor_ = nullptr;
   sensor::Sensor *cdu_ts_temp_sensor_ = nullptr;


### PR DESCRIPTION
This PR adds an "Indoor Temp" sensor entity to Home Assistant, mirroring the functionality of the existing "Outdoor Temp" sensor.

<img width="345" height="253" alt="image" src="https://github.com/user-attachments/assets/e59b7dde-efee-49ad-899d-120f8a450e4b" />
