### PR TITLE
Add time synchronization and native energy sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,18 @@ uart:
   parity: EVEN
   baud_rate: 9600
 
+# Optional. Required only if the energy/power sensor feature is enabled.
+# time:
+#   - platform: homeassistant
+#     id: hass_time
+
 climate:
   - platform: toshiba_suzumi
     name: living-room
     id: living_room
     uart_id: uart_bus
+    #time_id: hass_time  # Optional. Required only if the energy/power sensor feature is enabled.
+    #time_sync_interval: 24h  # Optional. Time sync interval. Default 24h. Set to 0 to sync only at startup.
     outdoor_temp:        # Optional. Outdoor temperature sensor
       name: Outdoor Temp
       filters:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ climate:
     uart_id: uart_bus
     #time_id: hass_time  # Optional. Required only if the energy/power sensor feature is enabled.
     #time_sync_interval: 24h  # Optional. Time sync interval. Default 24h. Set to 0 to sync only at startup.
+    #energy:  # Optional. Daily energy consumption sensor (Wh).
+    #  name: "Daily Energy"
+    #power:  # Optional. Estimated real-time power sensor (W).
+    #  name: "Realtime Power"
     outdoor_temp:        # Optional. Outdoor temperature sensor
       name: Outdoor Temp
       filters:
@@ -249,9 +253,30 @@ Some Toshiba AC units periodically send extended status messages from the outdoo
 
 These sensors are all optional — only add the ones you need to your YAML configuration. The data arrives automatically from the unit (no polling required).
 
-### Estimating power consumption
+### Native Energy and Power monitoring
 
-The AC protocol does not report actual power consumption in watts. However, `cdu_load` reports the compressor load as a percentage, which correlates with power usage. You can combine it with your unit's rated power input to estimate consumption in Home Assistant using a template sensor:
+If your AC unit supports it, you can now get native energy consumption data. This requires adding a `time` component to your configuration so the component can sync the current time with the AC unit.
+
+```yaml
+time:
+  - platform: homeassistant
+    id: hass_time
+
+climate:
+  - platform: toshiba_suzumi
+    # ...
+    time_id: hass_time
+    energy:
+      name: "Daily Energy"
+    power:
+      name: "Realtime Power"
+```
+
+The `power` sensor provides a real-time estimate in Watts, calculated from the rate of change in the AC's internal energy counters.
+
+### Estimating power consumption (Fallback)
+
+For older units that do not support the native energy registers, you can still estimate power using `cdu_load`. `cdu_load` reports the compressor load as a percentage, which correlates with power usage. You can combine it with your unit's rated power input to estimate consumption in Home Assistant using a template sensor:
 
 ```yaml
 sensor:

--- a/components/toshiba_suzumi/climate.py
+++ b/components/toshiba_suzumi/climate.py
@@ -10,6 +10,7 @@ from esphome.const import (
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_RUNNING,
+    CONF_TIME_ID,
     __version__ as ESPHOME_VERSION
 )
 from packaging import version
@@ -37,6 +38,7 @@ CONF_SPECIAL_MODE = "special_mode" # deprecated - replaced by CONF_SUPPORTED_PRE
 CONF_SPECIAL_MODE_MODES = "modes" # deprecated - replaced by CONF_SUPPORTED_PRESETS
 CONF_SUPPORTED_PRESETS = "supported_presets"
 CONF_SELF_CLEAN = "self_clean"
+CONF_TIME_SYNC_INTERVAL = "time_sync_interval"
 
 FEATURE_HORIZONTAL_SWING = "horizontal_swing"
 MIN_TEMP = "min_temp"
@@ -130,6 +132,8 @@ CONFIG_SCHEMA = climate.climate_schema(ToshibaClimateUart).extend(
         }),
         cv.Optional(CONF_SUPPORTED_PRESETS): cv.ensure_list(cv.one_of("Standard","Hi POWER","ECO","Fireplace 1","Fireplace 2","8 degrees","Silent#1","Silent#2","Sleep","Floor","Comfort")),
         cv.Optional(MIN_TEMP): cv.int_,
+        cv.Optional(CONF_TIME_ID): cv.use_id(cg.esphome_ns.namespace("time").class_("RealTimeClock")),
+        cv.Optional(CONF_TIME_SYNC_INTERVAL, default="24h"): cv.positive_time_period_milliseconds,
     }
 ).extend(uart.UART_DEVICE_SCHEMA).extend(cv.polling_component_schema("120s"))
 
@@ -221,3 +225,10 @@ async def to_code(config):
         if "8 degrees" in presets:
             # if "8 degrees" feature is in the list, set the min visual temperature to 5
             cg.add(var.set_min_temp(5))
+
+    if CONF_TIME_ID in config:
+        time_ = await cg.get_variable(config[CONF_TIME_ID])
+        cg.add(var.set_time(time_))
+
+    if CONF_TIME_SYNC_INTERVAL in config:
+        cg.add(var.set_time_sync_interval(config[CONF_TIME_SYNC_INTERVAL]))

--- a/components/toshiba_suzumi/climate.py
+++ b/components/toshiba_suzumi/climate.py
@@ -7,10 +7,15 @@ from esphome.const import (
     UNIT_CELSIUS,
     UNIT_PERCENT,
     UNIT_AMPERE,
+    UNIT_WATT_HOURS,
+    UNIT_WATT,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_RUNNING,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_POWER,
     CONF_TIME_ID,
+    STATE_CLASS_TOTAL_INCREASING,
     __version__ as ESPHOME_VERSION
 )
 from packaging import version
@@ -39,6 +44,8 @@ CONF_SPECIAL_MODE_MODES = "modes" # deprecated - replaced by CONF_SUPPORTED_PRES
 CONF_SUPPORTED_PRESETS = "supported_presets"
 CONF_SELF_CLEAN = "self_clean"
 CONF_TIME_SYNC_INTERVAL = "time_sync_interval"
+CONF_ENERGY = "energy"
+CONF_POWER = "power"
 
 FEATURE_HORIZONTAL_SWING = "horizontal_swing"
 MIN_TEMP = "min_temp"
@@ -134,6 +141,18 @@ CONFIG_SCHEMA = climate.climate_schema(ToshibaClimateUart).extend(
         cv.Optional(MIN_TEMP): cv.int_,
         cv.Optional(CONF_TIME_ID): cv.use_id(cg.esphome_ns.namespace("time").class_("RealTimeClock")),
         cv.Optional(CONF_TIME_SYNC_INTERVAL, default="24h"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_ENERGY): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT_HOURS,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
+            ),
+        cv.Optional(CONF_POWER): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
     }
 ).extend(uart.UART_DEVICE_SCHEMA).extend(cv.polling_component_schema("120s"))
 
@@ -232,3 +251,11 @@ async def to_code(config):
 
     if CONF_TIME_SYNC_INTERVAL in config:
         cg.add(var.set_time_sync_interval(config[CONF_TIME_SYNC_INTERVAL]))
+
+    if CONF_ENERGY in config:
+        sens = await sensor.new_sensor(config[CONF_ENERGY])
+        cg.add(var.set_energy_sensor(sens))
+
+    if CONF_POWER in config:
+        sens = await sensor.new_sensor(config[CONF_POWER])
+        cg.add(var.set_power_sensor(sens))

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -22,6 +22,10 @@ uint8_t checksum(std::vector<uint8_t> data, uint8_t length) {
   return 256 - sum;
 }
 
+ToshibaClimateUart::ToshibaClimateUart() {
+  this->last_time_sync_ = 0;
+}
+
 /**
  * Send the command to UART interface.
  */
@@ -189,6 +193,12 @@ void ToshibaClimateUart::setup() {
  */
 void ToshibaClimateUart::process_command_queue_() {
   uint32_t now = millis();
+
+  // Suspend command queue execution during the 5-second post-time-sync window
+  if (this->last_time_sync_ != 0 && now - this->last_time_sync_ < 5000) {
+    return;
+  }
+
   uint32_t cmdDelay = now - this->last_command_timestamp_;
 
   // when we have not processed message and timeout since last received byte has expired,
@@ -248,6 +258,11 @@ void ToshibaClimateUart::parseResponse(std::vector<uint8_t> rawData) {
       value = rawData[13];
       break;
     case 16:  // probably ACK for issued command
+      // Check if this is a SET_DATE_TIME ACK (ends in 0x99 0x99)
+      if (rawData[14] == 0x99) {
+          ESP_LOGD(TAG, "AC unit acknowledged time synchronization.");
+          this->time_synced_ = true;
+      }
       ESP_LOGD(TAG, "Received message with length: %d and value %s", length, format_hex_pretty(rawData).c_str());
       return;
     case 17:  // response to requestData with the actual value of sensor/setting
@@ -521,6 +536,17 @@ void ToshibaClimateUart::update() {
   if (this->self_clean_running_) {
     this->requestData(ToshibaCommandType::SELF_CLEAN);
   }
+
+  uint32_t now = millis();
+  // Sync time periodically based on configured interval, or every 5 minutes if it hasn't succeeded yet
+  if (this->time_ != nullptr) {
+    if (!this->time_synced_ || (this->time_sync_interval_ != 0 && now - this->last_time_sync_ > this->time_sync_interval_)) {
+      if (this->time_synced_ || (this->last_time_sync_ == 0 || now - this->last_time_sync_ > 300000)) {
+          ESP_LOGI(TAG, "Triggering scheduled time synchronization...");
+          this->sync_time_();
+      }
+    }
+  }
 }
 
 void ToshibaClimateUart::control(const climate::ClimateCall &call) {
@@ -786,6 +812,48 @@ void ToshibaClimateUart::set_wifi_led(bool enabled) {
     this->sendCmd(ToshibaCommandType::WIFI_LED_1, 0x00);
     this->sendCmd(ToshibaCommandType::WIFI_LED_2, 0x80);
   }
+}
+
+void ToshibaClimateUart::sync_time_() {
+  if (this->time_ == nullptr) {
+    ESP_LOGW(TAG, "Time sync requested but no time_id is configured in YAML!");
+    return;
+  }
+  if (!this->time_->now().is_valid()) {
+    ESP_LOGI(TAG, "Time sync requested but time source is not yet valid/synchronized.");
+    return;
+  }
+  auto now = this->time_->now();
+
+  ESP_LOGI(TAG, "Syncing time to AC unit: %04d-%02d-%02d %02d:%02d:%02d", now.year, now.month, now.day_of_month, now.hour,
+           now.minute, now.second);
+
+  std::vector<uint8_t> payload = {2, 0, 3, 16, 0, 0, 0xef, 1, 48, 1, 0, 0xea, 0x99};
+  payload.push_back((now.year - 2000) + 100);
+  payload.push_back(now.month - 1);
+  payload.push_back(now.day_of_month);
+  payload.push_back(now.hour);
+  payload.push_back(now.minute);
+  payload.push_back(now.second);
+  payload.push_back(now.day_of_week - 1); // Sunday=0
+  payload.push_back(0x00);
+  payload.push_back(0x00);
+  for (int i = 0; i < 224; i++) {
+    payload.push_back(0xFF);
+  }
+  payload.push_back(checksum(payload, payload.size()));
+
+  // Drain any pending RX bytes in the hardware buffer and clear parser RX state
+  while (this->available()) {
+    uint8_t dummy;
+    this->read_byte(&dummy);
+  }
+  this->rx_message_.clear();
+
+  // Send packet directly to bypass queue/chatty collision blockages
+  this->write_array(payload);
+  this->last_command_timestamp_ = millis();
+  this->last_time_sync_ = millis();
 }
 
 }  // namespace toshiba_suzumi

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -24,6 +24,12 @@ uint8_t checksum(std::vector<uint8_t> data, uint8_t length) {
 
 ToshibaClimateUart::ToshibaClimateUart() {
   this->last_time_sync_ = 0;
+  this->last_energy_sync_ = 0;
+  this->last_total_daily_energy_ = 0;
+  this->last_energy_update_ms_ = 0;
+  for (int i = 0; i < 24; i++) {
+    this->daily_energy_usage_[i] = 0;
+  }
 }
 
 /**
@@ -144,6 +150,9 @@ void ToshibaClimateUart::getInitData() {
   this->requestData(ToshibaCommandType::ROOM_TEMP);
   this->requestData(ToshibaCommandType::OUTDOOR_TEMP);
   this->requestData(ToshibaCommandType::SPECIAL_MODE);
+  if (this->energy_sensor_ != nullptr || this->power_sensor_ != nullptr) {
+    this->requestData(ToshibaCommandType::ENERGY_DAILY);
+  }
 }
 
 void ToshibaClimateUart::set_self_clean_running_(bool running) {
@@ -269,6 +278,11 @@ void ToshibaClimateUart::parseResponse(std::vector<uint8_t> rawData) {
       sensor = static_cast<ToshibaCommandType>(rawData[14]);
       value = rawData[15];
       break;
+    case 69:
+    case 70:  // energy daily response
+      sensor = static_cast<ToshibaCommandType>(rawData[14]);
+      value = 0;
+      break;
     case 22:  // extended status message (e.g., ODU_STATUS / IDU_STATUS)
       sensor = static_cast<ToshibaCommandType>(rawData[12]);
       value = 0;
@@ -283,6 +297,24 @@ void ToshibaClimateUart::parseResponse(std::vector<uint8_t> rawData) {
       return;
   }
   switch (sensor) {
+    case ToshibaCommandType::ENERGY_DAILY: {
+      ESP_LOGI(TAG, "Received daily energy update");
+      uint32_t total_energy = 0;
+      uint8_t current_hour = (this->time_ != nullptr) ? this->time_->now().hour : 25;
+      for (uint8_t i = 0; i < 24; i++) {
+        uint16_t hour_val = (rawData[21 + (i * 2) + 1] << 8) | rawData[21 + (i * 2)];
+        this->daily_energy_usage_[i] = hour_val;
+        total_energy += hour_val;
+        if (i == current_hour) {
+            ESP_LOGD(TAG, "  Current hour (%d) consumption: %u Wh", i, hour_val);
+        }
+      }
+      if (this->energy_sensor_ != nullptr) {
+        this->energy_sensor_->publish_state(total_energy);
+      }
+      this->estimate_wattage_(total_energy);
+      break;
+    }
     case ToshibaCommandType::TARGET_TEMP:
       ESP_LOGI(TAG, "Received target temp: %d", value);
       if (this->special_mode_ == SPECIAL_MODE::EIGHT_DEG) {
@@ -505,6 +537,12 @@ void ToshibaClimateUart::dump_config() {
   if (fcu_fan_rpm_sensor_ != nullptr) {
     LOG_SENSOR("", "FCU Fan RPM", this->fcu_fan_rpm_sensor_);
   }
+  if (energy_sensor_ != nullptr) {
+    LOG_SENSOR("", "Energy", this->energy_sensor_);
+  }
+  if (power_sensor_ != nullptr) {
+    LOG_SENSOR("", "Power", this->power_sensor_);
+  }
   if (pwr_select_ != nullptr) {
     LOG_SELECT("", "Power selector", this->pwr_select_);
   }
@@ -546,6 +584,11 @@ void ToshibaClimateUart::update() {
           this->sync_time_();
       }
     }
+  }
+
+  // Periodic Energy Sync (Runs every 60s if energy or power sensors are configured)
+  if ((this->energy_sensor_ != nullptr || this->power_sensor_ != nullptr) && (now - this->last_energy_sync_ > 60000)) {
+    this->sync_energy_();
   }
 }
 
@@ -854,6 +897,38 @@ void ToshibaClimateUart::sync_time_() {
   this->write_array(payload);
   this->last_command_timestamp_ = millis();
   this->last_time_sync_ = millis();
+}
+
+void ToshibaClimateUart::sync_energy_() {
+  ESP_LOGV(TAG, "Syncing energy data");
+  this->requestData(ToshibaCommandType::ENERGY_DAILY);
+  this->last_energy_sync_ = millis();
+}
+
+void ToshibaClimateUart::estimate_wattage_(uint32_t current_energy) {
+  uint32_t now = millis();
+  if (this->last_energy_update_ms_ == 0 || current_energy < this->last_total_daily_energy_) {
+    this->last_total_daily_energy_ = current_energy;
+    this->last_energy_update_ms_ = now;
+    return;
+  }
+
+  uint32_t energy_diff = current_energy - this->last_total_daily_energy_;
+  uint32_t time_diff = now - this->last_energy_update_ms_;
+
+  if (time_diff > 0 && energy_diff > 0) {
+    float wattage = (energy_diff * 3600000.0f) / time_diff;
+    if (this->power_sensor_ != nullptr) {
+      this->power_sensor_->publish_state(wattage);
+    }
+  } else if (energy_diff == 0) {
+    if (this->power_sensor_ != nullptr) {
+      this->power_sensor_->publish_state(0);
+    }
+  }
+
+  this->last_total_daily_energy_ = current_energy;
+  this->last_energy_update_ms_ = now;
 }
 
 }  // namespace toshiba_suzumi

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -571,14 +571,10 @@ void ToshibaClimateUart::update() {
   }
 
   uint32_t now = millis();
-  // Sync time periodically based on configured interval, or every 5 minutes if it hasn't succeeded yet
+
+  // Handle time synchronization
   if (this->time_ != nullptr) {
-    if (!this->time_synced_ || (this->time_sync_interval_ != 0 && now - this->last_time_sync_ > this->time_sync_interval_)) {
-      if (this->time_synced_ || (this->last_time_sync_ == 0 || now - this->last_time_sync_ > 300000)) {
-          ESP_LOGI(TAG, "Triggering scheduled time synchronization...");
-          this->sync_time_();
-      }
-    }
+    this->check_time_sync_(now);
   }
 
   // Periodic Energy Sync (Runs every 60s if energy or power sensors are configured)
@@ -849,6 +845,25 @@ void ToshibaClimateUart::set_wifi_led(bool enabled) {
     ESP_LOGI(TAG, "Turning OFF Wi-Fi LED");
     this->sendCmd(ToshibaCommandType::WIFI_LED_1, 0x00);
     this->sendCmd(ToshibaCommandType::WIFI_LED_2, 0x80);
+  }
+}
+
+void ToshibaClimateUart::check_time_sync_(uint32_t now) {
+  if (!this->time_synced_) {
+    // Boot sync or retry every 5 minutes until synchronized
+    if (this->last_time_sync_ == 0) {
+      ESP_LOGI(TAG, "Triggering initial time synchronization...");
+      this->sync_time_();
+    } else if (now - this->last_time_sync_ > 300000) {
+      ESP_LOGI(TAG, "Retrying time synchronization...");
+      this->sync_time_();
+    }
+  } else if (this->time_sync_interval_ != 0) {
+    // Periodic synchronization after initial success
+    if (now - this->last_time_sync_ > this->time_sync_interval_) {
+      ESP_LOGI(TAG, "Triggering periodic time synchronization...");
+      this->sync_time_();
+    }
   }
 }
 

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -203,11 +203,6 @@ void ToshibaClimateUart::setup() {
 void ToshibaClimateUart::process_command_queue_() {
   uint32_t now = millis();
 
-  // Suspend command queue execution during the 5-second post-time-sync window
-  if (this->last_time_sync_ != 0 && now - this->last_time_sync_ < 5000) {
-    return;
-  }
-
   uint32_t cmdDelay = now - this->last_command_timestamp_;
 
   // when we have not processed message and timeout since last received byte has expired,
@@ -886,16 +881,9 @@ void ToshibaClimateUart::sync_time_() {
   }
   payload.push_back(checksum(payload, payload.size()));
 
-  // Drain any pending RX bytes in the hardware buffer and clear parser RX state
-  while (this->available()) {
-    uint8_t dummy;
-    this->read_byte(&dummy);
-  }
-  this->rx_message_.clear();
-
-  // Send packet directly to bypass queue/chatty collision blockages
-  this->write_array(payload);
-  this->last_command_timestamp_ = millis();
+  // Enqueue the time sync packet and a 5-second delay to prevent collisions
+  this->enqueue_command_(ToshibaCommand{.cmd = ToshibaCommandType::SET_DATE_TIME, .payload = payload});
+  this->enqueue_command_(ToshibaCommand{.cmd = ToshibaCommandType::DELAY, .delay = 5000});
   this->last_time_sync_ = millis();
 }
 

--- a/components/toshiba_suzumi/toshiba_climate.h
+++ b/components/toshiba_suzumi/toshiba_climate.h
@@ -62,6 +62,8 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void set_fcu_tcj_temp_sensor(sensor::Sensor *sensor) { fcu_tcj_temp_sensor_ = sensor; }
   void set_fcu_fan_rpm_sensor(sensor::Sensor *sensor) { fcu_fan_rpm_sensor_ = sensor; }
   void set_time(time::RealTimeClock *time) { time_ = time; }
+  void set_energy_sensor(sensor::Sensor *sensor) { energy_sensor_ = sensor; }
+  void set_power_sensor(sensor::Sensor *sensor) { power_sensor_ = sensor; }
   void set_pwr_select(select::Select *pws_select) { pwr_select_ = pws_select; }
   void set_vertical_air_direction_select(select::Select *vertical_air_direction_select) {
     vertical_air_direction_select_ = vertical_air_direction_select;
@@ -104,12 +106,18 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   sensor::Sensor *fcu_tcj_temp_sensor_ = nullptr;
   sensor::Sensor *fcu_fan_rpm_sensor_ = nullptr;
   time::RealTimeClock *time_ = nullptr;
+  sensor::Sensor *energy_sensor_ = nullptr;
+  sensor::Sensor *power_sensor_ = nullptr;
   bool horizontal_swing_ = false;
   uint8_t min_temp_ = 17; // default min temp for units without 8° heating mode
   bool heat_mode_disabled_ = false;
   bool wifi_led_disabled_ = false;
   std::vector<const char*> supported_presets_;
   uint32_t last_time_sync_ = 0;
+  uint32_t last_energy_sync_ = 0;
+  uint32_t last_total_daily_energy_ = 0;
+  uint32_t last_energy_update_ms_ = 0;
+  uint16_t daily_energy_usage_[24] = {0};
   bool time_synced_ = false;
   uint32_t time_sync_interval_{86400000};
 
@@ -129,6 +137,8 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void publish_vertical_air_direction_(SWING swing_mode);
   void configure_supported_custom_modes_();
   void sync_time_();
+  void sync_energy_();
+  void estimate_wattage_(uint32_t current_energy);
 
   friend class ToshibaPwrModeSelect;
   friend class ToshibaVerticalAirDirectionSelect;

--- a/components/toshiba_suzumi/toshiba_climate.h
+++ b/components/toshiba_suzumi/toshiba_climate.h
@@ -136,6 +136,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void on_set_vertical_air_direction(const std::string &value);
   void publish_vertical_air_direction_(SWING swing_mode);
   void configure_supported_custom_modes_();
+  void check_time_sync_(uint32_t now);
   void sync_time_();
   void sync_energy_();
   void estimate_wattage_(uint32_t current_energy);

--- a/components/toshiba_suzumi/toshiba_climate.h
+++ b/components/toshiba_suzumi/toshiba_climate.h
@@ -6,6 +6,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/select/select.h"
+#include "esphome/components/time/real_time_clock.h"
 #include "toshiba_climate_mode.h"
 
 namespace esphome {
@@ -40,6 +41,8 @@ struct ToshibaCommand {
 
 class ToshibaClimateUart : public PollingComponent, public climate::Climate, public uart::UARTDevice {
  public:
+  ToshibaClimateUart();
+
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -58,6 +61,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void set_fcu_tc_temp_sensor(sensor::Sensor *sensor) { fcu_tc_temp_sensor_ = sensor; }
   void set_fcu_tcj_temp_sensor(sensor::Sensor *sensor) { fcu_tcj_temp_sensor_ = sensor; }
   void set_fcu_fan_rpm_sensor(sensor::Sensor *sensor) { fcu_fan_rpm_sensor_ = sensor; }
+  void set_time(time::RealTimeClock *time) { time_ = time; }
   void set_pwr_select(select::Select *pws_select) { pwr_select_ = pws_select; }
   void set_vertical_air_direction_select(select::Select *vertical_air_direction_select) {
     vertical_air_direction_select_ = vertical_air_direction_select;
@@ -68,6 +72,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void disable_wifi_led(bool disabled) { wifi_led_disabled_ = disabled; }
   void set_supported_presets(const std::vector<const char *> &presets) { supported_presets_ = presets; }
   void set_min_temp(uint8_t min_temp) { min_temp_ = min_temp; }
+  void set_time_sync_interval(uint32_t interval) { time_sync_interval_ = interval; }
 
  protected:
   /// Override control to change settings of the climate device.
@@ -98,11 +103,15 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   sensor::Sensor *fcu_tc_temp_sensor_ = nullptr;
   sensor::Sensor *fcu_tcj_temp_sensor_ = nullptr;
   sensor::Sensor *fcu_fan_rpm_sensor_ = nullptr;
+  time::RealTimeClock *time_ = nullptr;
   bool horizontal_swing_ = false;
   uint8_t min_temp_ = 17; // default min temp for units without 8° heating mode
   bool heat_mode_disabled_ = false;
   bool wifi_led_disabled_ = false;
   std::vector<const char*> supported_presets_;
+  uint32_t last_time_sync_ = 0;
+  bool time_synced_ = false;
+  uint32_t time_sync_interval_{86400000};
 
   void enqueue_command_(const ToshibaCommand &command);
   void send_to_uart(const ToshibaCommand command);
@@ -119,6 +128,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void on_set_vertical_air_direction(const std::string &value);
   void publish_vertical_air_direction_(SWING swing_mode);
   void configure_supported_custom_modes_();
+  void sync_time_();
 
   friend class ToshibaPwrModeSelect;
   friend class ToshibaVerticalAirDirectionSelect;

--- a/components/toshiba_suzumi/toshiba_climate_mode.h
+++ b/components/toshiba_suzumi/toshiba_climate_mode.h
@@ -85,6 +85,10 @@ enum class ToshibaCommandType : uint8_t {
   WIFI_LED_2 = 223,
   SELF_CLEAN = 0xCB,
   SPECIAL_MODE = 247,
+  ENERGY_DAILY = 0xD8,
+  ENERGY_WEEKLY = 0xD9,
+  ENERGY_MONTHLY = 0xDA,
+  ENERGY_YEARLY = 0xDB,
   SET_DATE_TIME = 0xEA,
   IDU_STATUS = 0xE4,   // 228 - Indoor unit status (unsolicited)
   ODU_STATUS = 0xE5,   // 229 - Outdoor unit status (unsolicited)

--- a/components/toshiba_suzumi/toshiba_climate_mode.h
+++ b/components/toshiba_suzumi/toshiba_climate_mode.h
@@ -85,6 +85,7 @@ enum class ToshibaCommandType : uint8_t {
   WIFI_LED_2 = 223,
   SELF_CLEAN = 0xCB,
   SPECIAL_MODE = 247,
+  SET_DATE_TIME = 0xEA,
   IDU_STATUS = 0xE4,   // 228 - Indoor unit status (unsolicited)
   ODU_STATUS = 0xE5,   // 229 - Outdoor unit status (unsolicited)
 };


### PR DESCRIPTION
I have added the time sync and energy sensor that working good on my Carrier Copper 11 (Thailand) unit.

I need help from everyone here to test this feature on other brand or model.

Special thanks @maxmacstn for protocol references from https://github.com/maxmacstn/ToshibaCarrierController/tree/main/src

You can test by changing on your ESPHome manifest to my branch

```yaml
external_components:
  - source:
      type: git
      url: https://github.com/rtsp/esphome_toshiba_suzumi
      ref: native-energy-sensor
    components: [toshiba_suzumi]
    refresh: 0s
```

Then add energy configuration like this and reinstall the firmware.

```yaml
time:
  - platform: homeassistant
    id: hass_time

climate:
  - platform: toshiba_suzumi
    ...
    ...
    time_id: hass_time
    energy:
      name: Daily Energy
    power:
      name: Realtime Power
```