### PR TITLE
Add fixed vertical air direction control

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ climate:
         - filter_out: 127 
     power_select:
       name: "Power level"
+    #vertical_air_direction: # Optional. Fixed vertical air direction.
+      # Controls the Toshiba horizontal louver, which directs air up/down.
+      #name: "Vertical air direction"
     #horizontal_swing: true # Optional. Uncomment if your HVAC supports also horizontal swing
     #supported_presets:          # Optional. Enable only the features your HVAC
       #- "Standard"
@@ -187,6 +190,19 @@ You can filter unwanted values by adding a filter to Outside temp sensor:
       filters:
         - filter_out: 127 
 ```
+
+### Vertical air directions
+
+Some units support fixed vertical air directions in addition to vertical swing. ESPHome's native climate swing modes are limited to `off`, `vertical`, `horizontal`, and `both`, so fixed positions are exposed as a Home Assistant select entity:
+
+```yaml
+    vertical_air_direction:
+      name: "Vertical air direction"
+```
+
+In Toshiba service documentation this corresponds to the horizontal louver, which controls vertical air direction.
+
+The select provides `Off`, `Swing`, `Top`, `Middle Top`, `Middle`, `Middle Bottom`, and `Bottom`.
 
 ## Outdoor/Indoor unit diagnostics (ODU/IDU sensors)
 

--- a/components/toshiba_suzumi/climate.py
+++ b/components/toshiba_suzumi/climate.py
@@ -31,6 +31,7 @@ CONF_FCU_TC_TEMP = "fcu_tc_temp"
 CONF_FCU_TCJ_TEMP = "fcu_tcj_temp"
 CONF_FCU_FAN_RPM = "fcu_fan_rpm"
 CONF_PWR_SELECT = "power_select"
+CONF_VERTICAL_AIR_DIRECTION = "vertical_air_direction"
 CONF_SPECIAL_MODE = "special_mode" # deprecated - replaced by CONF_SUPPORTED_PRESETS
 CONF_SPECIAL_MODE_MODES = "modes" # deprecated - replaced by CONF_SUPPORTED_PRESETS
 CONF_SUPPORTED_PRESETS = "supported_presets"
@@ -44,6 +45,7 @@ toshiba_ns = cg.esphome_ns.namespace("toshiba_suzumi")
 ToshibaClimateUart = toshiba_ns.class_("ToshibaClimateUart", cg.PollingComponent, climate.Climate, uart.UARTDevice)
 ToshibaPwrModeSelect = toshiba_ns.class_('ToshibaPwrModeSelect', select.Select)
 ToshibaSpecialModeSelect = toshiba_ns.class_('ToshibaSpecialModeSelect', select.Select)
+ToshibaVerticalAirDirectionSelect = toshiba_ns.class_('ToshibaVerticalAirDirectionSelect', select.Select)
 
 CONFIG_SCHEMA = climate.climate_schema(ToshibaClimateUart).extend(
     {
@@ -108,6 +110,9 @@ CONFIG_SCHEMA = climate.climate_schema(ToshibaClimateUart).extend(
             ),
         cv.Optional(CONF_PWR_SELECT): select.select_schema(ToshibaPwrModeSelect).extend({
             cv.GenerateID(): cv.declare_id(ToshibaPwrModeSelect),
+        }),
+        cv.Optional(CONF_VERTICAL_AIR_DIRECTION): select.select_schema(ToshibaVerticalAirDirectionSelect).extend({
+            cv.GenerateID(): cv.declare_id(ToshibaVerticalAirDirectionSelect),
         }),
         cv.Optional(FEATURE_HORIZONTAL_SWING): cv.boolean,
         cv.Optional(DISABLE_WIFI_LED): cv.boolean,
@@ -175,6 +180,11 @@ async def to_code(config):
         sel = await select.new_select(config[CONF_PWR_SELECT], options=['50 %', '75 %', '100 %'])
         await cg.register_parented(sel, config[CONF_ID])
         cg.add(var.set_pwr_select(sel))
+
+    if CONF_VERTICAL_AIR_DIRECTION in config:
+        sel = await select.new_select(config[CONF_VERTICAL_AIR_DIRECTION], options=['Off', 'Swing', 'Top', 'Middle Top', 'Middle', 'Middle Bottom', 'Bottom'])
+        await cg.register_parented(sel, config[CONF_ID])
+        cg.add(var.set_vertical_air_direction_select(sel))
 
     if FEATURE_HORIZONTAL_SWING in config:
         cg.add(var.set_horizontal_swing(True))

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -266,9 +266,20 @@ void ToshibaClimateUart::parseResponse(std::vector<uint8_t> rawData) {
       break;
     }
     case ToshibaCommandType::SWING: {
-      auto swingMode = IntToClimateSwingMode(static_cast<SWING>(value));
-      ESP_LOGI(TAG, "Received swing mode: %s", climate_swing_mode_to_string(swingMode));
-      this->swing_mode = swingMode;
+      auto swing = static_cast<SWING>(value);
+      auto air_direction = SwingToVerticalAirDirection(swing);
+      if (air_direction != nullptr) {
+        ESP_LOGI(TAG, "Received vertical air direction: %s", air_direction);
+        this->publish_vertical_air_direction_(swing);
+      }
+
+      if (IsFixedVerticalAirDirection(swing)) {
+        this->swing_mode = climate::CLIMATE_SWING_OFF;
+      } else {
+        auto swingMode = IntToClimateSwingMode(swing);
+        ESP_LOGI(TAG, "Received swing mode: %s", climate_swing_mode_to_string(swingMode));
+        this->swing_mode = swingMode;
+      }
       break;
     }
     case ToshibaCommandType::MODE: {
@@ -408,6 +419,9 @@ void ToshibaClimateUart::dump_config() {
   if (pwr_select_ != nullptr) {
     LOG_SELECT("", "Power selector", this->pwr_select_);
   }
+  if (vertical_air_direction_select_ != nullptr) {
+    LOG_SELECT("", "Vertical air direction", this->vertical_air_direction_select_);
+  }
   if (!supported_presets_.empty()) {
     ESP_LOGCONFIG(TAG, "Supported presets:");
     for (const char* &preset : supported_presets_) {
@@ -506,6 +520,7 @@ void ToshibaClimateUart::control(const climate::ClimateCall &call) {
     ESP_LOGD(TAG, "Setting swing mode to %s", climate_swing_mode_to_string(swing_mode));
     this->swing_mode = swing_mode;
     this->sendCmd(ToshibaCommandType::SWING, static_cast<uint8_t>(function_value));
+    this->publish_vertical_air_direction_(function_value);
   }
 
   if (call.get_preset().has_value()) {
@@ -642,6 +657,36 @@ void ToshibaClimateUart::on_set_pwr_level(const std::string &value) {
 }
 
 void ToshibaPwrModeSelect::control(const std::string &value) { parent_->on_set_pwr_level(value); }
+
+void ToshibaClimateUart::on_set_vertical_air_direction(const std::string &value) {
+  auto position = StringToVerticalAirDirection(value);
+  if (!position.has_value()) {
+    ESP_LOGW(TAG, "Unknown vertical air direction: %s", value.c_str());
+    return;
+  }
+
+  ESP_LOGD(TAG, "Setting vertical air direction to %s", value.c_str());
+  this->sendCmd(ToshibaCommandType::SWING, static_cast<uint8_t>(position.value()));
+  this->publish_vertical_air_direction_(position.value());
+  if (position.value() == SWING::VERTICAL || position.value() == SWING::BOTH) {
+    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+  } else {
+    this->swing_mode = climate::CLIMATE_SWING_OFF;
+  }
+  this->publish_state();
+}
+
+void ToshibaClimateUart::publish_vertical_air_direction_(SWING swing_mode) {
+  if (vertical_air_direction_select_ == nullptr) {
+    return;
+  }
+  auto position = SwingToVerticalAirDirection(swing_mode);
+  if (position != nullptr) {
+    vertical_air_direction_select_->publish_state(position);
+  }
+}
+
+void ToshibaVerticalAirDirectionSelect::control(const std::string &value) { parent_->on_set_vertical_air_direction(value); }
 
 /**
  * Scan all statuses from 128 to 255 in order to find unknown features.

--- a/components/toshiba_suzumi/toshiba_climate.h
+++ b/components/toshiba_suzumi/toshiba_climate.h
@@ -58,6 +58,9 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void set_fcu_tcj_temp_sensor(sensor::Sensor *sensor) { fcu_tcj_temp_sensor_ = sensor; }
   void set_fcu_fan_rpm_sensor(sensor::Sensor *sensor) { fcu_fan_rpm_sensor_ = sensor; }
   void set_pwr_select(select::Select *pws_select) { pwr_select_ = pws_select; }
+  void set_vertical_air_direction_select(select::Select *vertical_air_direction_select) {
+    vertical_air_direction_select_ = vertical_air_direction_select;
+  }
   void set_horizontal_swing(bool enabled) { horizontal_swing_ = enabled; }
   void disable_heat_mode(bool disabled) { heat_mode_disabled_ = disabled; }
   void disable_wifi_led(bool disabled) { wifi_led_disabled_ = disabled; }
@@ -79,6 +82,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   STATE power_state_ = STATE::OFF;
   optional<SPECIAL_MODE> special_mode_ = SPECIAL_MODE::STANDARD;
   select::Select *pwr_select_ = nullptr;
+  select::Select *vertical_air_direction_select_ = nullptr;
   sensor::Sensor *indoor_temp_sensor_ = nullptr;
   sensor::Sensor *outdoor_temp_sensor_ = nullptr;
   sensor::Sensor *cdu_td_temp_sensor_ = nullptr;
@@ -106,11 +110,19 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void handle_rx_byte_(uint8_t c);
   bool validate_message_();
   void on_set_pwr_level(const std::string &value);
+  void on_set_vertical_air_direction(const std::string &value);
+  void publish_vertical_air_direction_(SWING swing_mode);
 
   friend class ToshibaPwrModeSelect;
+  friend class ToshibaVerticalAirDirectionSelect;
 };
 
 class ToshibaPwrModeSelect : public select::Select, public esphome::Parented<ToshibaClimateUart> {
+ protected:
+  virtual void control(const std::string &value) override;
+};
+
+class ToshibaVerticalAirDirectionSelect : public select::Select, public esphome::Parented<ToshibaClimateUart> {
  protected:
   virtual void control(const std::string &value) override;
 };

--- a/components/toshiba_suzumi/toshiba_climate_mode.cpp
+++ b/components/toshiba_suzumi/toshiba_climate_mode.cpp
@@ -98,6 +98,53 @@ const std::string IntToPowerLevel(PWR_LEVEL mode) {
   }
 }
 
+struct VerticalAirDirection {
+  SWING swing;
+  const char *name;
+};
+
+// Toshiba service manuals call the physical up/down flap a horizontal louver;
+// expose the user-facing effect as vertical air direction.
+static const VerticalAirDirection VERTICAL_AIR_DIRECTIONS[] = {
+    {SWING::OFF, "Off"},
+    {SWING::VERTICAL, "Swing"},
+    {SWING::VERTICAL_FIX_POSITION_1, "Top"},
+    {SWING::VERTICAL_FIX_POSITION_2, "Middle Top"},
+    {SWING::VERTICAL_FIX_POSITION_3, "Middle"},
+    {SWING::VERTICAL_FIX_POSITION_4, "Middle Bottom"},
+    {SWING::VERTICAL_FIX_POSITION_5, "Bottom"},
+};
+
+const optional<SWING> StringToVerticalAirDirection(const std::string &position) {
+  for (auto const &direction : VERTICAL_AIR_DIRECTIONS) {
+    if (str_equals_case_insensitive(position, direction.name)) {
+      return direction.swing;
+    }
+  }
+  return nullopt;
+}
+
+const char* SwingToVerticalAirDirection(SWING mode) {
+  if (mode == SWING::HORIZONTAL) {
+    mode = SWING::OFF;
+  }
+  if (mode == SWING::BOTH) {
+    mode = SWING::VERTICAL;
+  }
+  for (auto const &direction : VERTICAL_AIR_DIRECTIONS) {
+    if (mode == direction.swing) {
+      return direction.name;
+    }
+  }
+  return nullptr;
+}
+
+bool IsFixedVerticalAirDirection(SWING mode) {
+  auto value = static_cast<uint8_t>(mode);
+  return value >= static_cast<uint8_t>(SWING::VERTICAL_FIX_POSITION_1) &&
+         value <= static_cast<uint8_t>(SWING::VERTICAL_FIX_POSITION_5);
+}
+
 const SWING ClimateSwingModeToInt(climate::ClimateSwingMode mode) {
   switch (mode) {
     case climate::CLIMATE_SWING_OFF:

--- a/components/toshiba_suzumi/toshiba_climate_mode.h
+++ b/components/toshiba_suzumi/toshiba_climate_mode.h
@@ -39,7 +39,17 @@ enum class FAN {
   FAN_HIGH = 54,
   FAN_AUTO = 65
 };
-enum class SWING { OFF = 49, BOTH =  67, VERTICAL = 65, HORIZONTAL = 66 };
+enum class SWING {
+  OFF = 49,
+  BOTH = 67,
+  VERTICAL = 65,
+  HORIZONTAL = 66,
+  VERTICAL_FIX_POSITION_1 = 80,
+  VERTICAL_FIX_POSITION_2 = 81,
+  VERTICAL_FIX_POSITION_3 = 82,
+  VERTICAL_FIX_POSITION_4 = 83,
+  VERTICAL_FIX_POSITION_5 = 84
+};
 enum class STATE { ON = 48, OFF = 49 };
 enum class PWR_LEVEL { PCT_50 = 50, PCT_75 = 75, PCT_100 = 100 };
 
@@ -91,6 +101,10 @@ const char* IntToCustomFanMode(FAN mode);
 
 const optional<PWR_LEVEL> StringToPwrLevel(const std::string &mode);
 const std::string IntToPowerLevel(PWR_LEVEL mode);
+
+const optional<SWING> StringToVerticalAirDirection(const std::string &position);
+const char* SwingToVerticalAirDirection(SWING mode);
+bool IsFixedVerticalAirDirection(SWING mode);
 
 const optional<SPECIAL_MODE> PresetToSpecialMode(const char* preset);
 const char* SpecialModeToPreset(SPECIAL_MODE mode);

--- a/example.yaml
+++ b/example.yaml
@@ -34,6 +34,9 @@ climate:
         - filter_out: 127 
     power_select:
       name: "Power level"
+    #vertical_air_direction: # Optional. Fixed vertical air direction.
+      # Controls the Toshiba horizontal louver, which directs air up/down.
+      #name: "Vertical air direction"
     #horizontal_swing: true # Optional. Uncomment if your HVAC supports also horizontal swing
     #supported_presets:          # Optional. Enable only the features your HVAC
       #- "Standard"

--- a/example_esp8266.yaml
+++ b/example_esp8266.yaml
@@ -31,6 +31,9 @@ climate:
         - filter_out: 127 
     power_select:
       name: "Power level"
+    #vertical_air_direction: # Optional. Fixed vertical air direction.
+      # Controls the Toshiba horizontal louver, which directs air up/down.
+      #name: "Vertical air direction"
     #horizontal_swing: true # Optional. Uncomment if your HVAC supports also horizontal swing
     #supported_presets:          # Optional. Enable only the features your HVAC
       #- "Standard"


### PR DESCRIPTION
## Summary

Fixes #52.

Adds an optional `vertical_air_direction` select entity for Toshiba units that support fixed up/down air directions.

The select provides:

- Off
- Swing
- Top
- Middle Top
- Middle
- Middle Bottom
- Bottom

Fixed positions use the Toshiba `SWING` command values `80` through `84`. Selecting a fixed position sets the climate swing mode to `off`; selecting `Swing` sets it to vertical swing.

The option is disabled unless explicitly configured. Documentation and examples describe the configuration and Toshiba terminology: the physical part is a horizontal louver, while its user-facing effect is vertical air direction.

## Testing

- `esphome compile ilp-c3u.yaml`
- Manually tested on a Toshiba Seiya Plus 16 (`RAS-B16E2KVG-E`):
  - verified vertical swing on/off
  - verified five distinct fixed louver positions
  - verified that the value after the fifth position has no effect

## Design notes / open questions

### Fixed-position labels

The fixed positions are named `Top`, `Middle Top`, `Middle`, `Middle Bottom`, and `Bottom`.

These names describe the resulting air direction rather than an action such as `Up` or `Down`. Home Assistant's climate model does not define names for fixed air-direction positions, so this is not intended to match a Home Assistant standard. Alternatives include `Up`, `Mid Up`, `Middle`, `Mid Down`, `Down`, or numbered positions such as `Position 1` through `Position 5`. Toshiba's documentation shows five fixed louver positions but does not assign them individual names.

### Climate integration model

ESPHome's climate swing modes currently represent only `off`, `vertical`, `horizontal`, and `both`. The fixed positions are therefore exposed as a separate select entity.

A more complete long-term approach may be to extend ESPHome, and potentially Home Assistant's climate entity model, to represent custom swing/air-direction positions. This would allow fixed positions to be represented as climate state instead of a separate select.

### Horizontal air direction compatibility

The implementation has only been tested on a unit with vertical air-direction control through the horizontal louver. It has not been tested on a unit supporting horizontal air direction or combined swing. In particular, the interaction between fixed vertical positions and horizontal/both swing modes needs verification on such hardware.

### Protocol scope

The fixed-position values `80` through `84` are treated as five contiguous vertical positions. This matches manual testing on the Seiya Plus 16 and the values used by the [OpenKNX Toshiba driver](https://github.com/OpenKNX/OAM-Aircondition/blob/v1/src/Driver/Toshiba/ToshibaDriver.h#L79), but may not apply to every Toshiba model.

### State handling

The select state is updated immediately after sending a command and is also updated from received `SWING` status messages. This keeps Home Assistant responsive, but assumes that the unit accepts the command; the protocol does not currently provide a dedicated acknowledgement flow for this control.
