### PR TITLE
Add optional self-clean (post-shutdown self-cleaning) status

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ climate:
     #vertical_air_direction: # Optional. Fixed vertical air direction.
       # Controls the Toshiba horizontal louver, which directs air up/down.
       #name: "Vertical air direction"
+    #self_clean:              # Optional. Enables self-clean detection and reports its status.
+      #name: "Self Clean"
     #horizontal_swing: true # Optional. Uncomment if your HVAC supports also horizontal swing
     #supported_presets:          # Optional. Enable only the features your HVAC
       #- "Standard"
@@ -203,6 +205,23 @@ Some units support fixed vertical air directions in addition to vertical swing. 
 In Toshiba service documentation this corresponds to the horizontal louver, which controls vertical air direction.
 
 The select provides `Off`, `Swing`, `Top`, `Middle Top`, `Middle`, `Middle Bottom`, and `Bottom`.
+
+### Self-cleaning status
+
+Some Toshiba units run a post-shutdown self-cleaning cycle. During this cycle the indoor fan can continue running even though the climate entity is off. Configure the optional `self_clean` binary sensor to enable self-clean detection and expose the cycle in Home Assistant:
+
+```yaml
+    self_clean:
+      name: "Self Clean"
+```
+
+The climate entity remains OFF while self-cleaning is active. ESPHome climate entities do not have a self-cleaning mode or action, so the binary sensor reports this separate operating state. Without `self_clean`, the component does not query self-clean status and retains its existing climate behavior.
+
+How the cycle behaves (per the Toshiba service manual):
+
+- It runs only after cooling or dry operation, and only if that ran for at least 10 minutes; it then runs for a fixed ~30 minutes. It does not run after heating, fan-only, or a short (<10 min) cooling/dry run.
+- During the cycle the indoor fan runs at low speed to dry the unit; the compressor stays off. The unit reports itself as not operating, which is why the climate entity is OFF.
+- The service manual documents enabling/disabling the self-clean cycle as a unit-side procedure (the indoor unit's `RESET` button together with a remote-control diagnosis code). This component reports the cycle but does not control it.
 
 ## Outdoor/Indoor unit diagnostics (ODU/IDU sensors)
 

--- a/components/toshiba_suzumi/climate.py
+++ b/components/toshiba_suzumi/climate.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import sensor, climate, uart, select
+from esphome.components import binary_sensor, sensor, climate, uart, select
 from esphome.const import (
     CONF_ID,
     STATE_CLASS_MEASUREMENT,
@@ -9,6 +9,7 @@ from esphome.const import (
     UNIT_AMPERE,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_RUNNING,
     __version__ as ESPHOME_VERSION
 )
 from packaging import version
@@ -17,7 +18,7 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["sensor", "select"]
+AUTO_LOAD = ["binary_sensor", "sensor", "select"]
 
 CONF_ROOM_TEMP = "room_temp"
 CONF_INDOOR_TEMP = "indoor_temp"
@@ -35,6 +36,7 @@ CONF_VERTICAL_AIR_DIRECTION = "vertical_air_direction"
 CONF_SPECIAL_MODE = "special_mode" # deprecated - replaced by CONF_SUPPORTED_PRESETS
 CONF_SPECIAL_MODE_MODES = "modes" # deprecated - replaced by CONF_SUPPORTED_PRESETS
 CONF_SUPPORTED_PRESETS = "supported_presets"
+CONF_SELF_CLEAN = "self_clean"
 
 FEATURE_HORIZONTAL_SWING = "horizontal_swing"
 MIN_TEMP = "min_temp"
@@ -114,6 +116,9 @@ CONFIG_SCHEMA = climate.climate_schema(ToshibaClimateUart).extend(
         cv.Optional(CONF_VERTICAL_AIR_DIRECTION): select.select_schema(ToshibaVerticalAirDirectionSelect).extend({
             cv.GenerateID(): cv.declare_id(ToshibaVerticalAirDirectionSelect),
         }),
+        cv.Optional(CONF_SELF_CLEAN): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_RUNNING
+        ),
         cv.Optional(FEATURE_HORIZONTAL_SWING): cv.boolean,
         cv.Optional(DISABLE_WIFI_LED): cv.boolean,
         cv.Optional(DISABLE_HEAT_MODE): cv.boolean,
@@ -185,6 +190,9 @@ async def to_code(config):
         sel = await select.new_select(config[CONF_VERTICAL_AIR_DIRECTION], options=['Off', 'Swing', 'Top', 'Middle Top', 'Middle', 'Middle Bottom', 'Bottom'])
         await cg.register_parented(sel, config[CONF_ID])
         cg.add(var.set_vertical_air_direction_select(sel))
+    if CONF_SELF_CLEAN in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_SELF_CLEAN])
+        cg.add(var.set_self_clean_sensor(sens))
 
     if FEATURE_HORIZONTAL_SWING in config:
         cg.add(var.set_horizontal_swing(True))

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -129,6 +129,9 @@ void ToshibaClimateUart::requestData(ToshibaCommandType cmd) {
 void ToshibaClimateUart::getInitData() {
   ESP_LOGD(TAG, "Requesting initial data from AC unit");
   this->requestData(ToshibaCommandType::POWER_STATE);
+  if (this->self_clean_sensor_ != nullptr) {
+    this->requestData(ToshibaCommandType::SELF_CLEAN);
+  }
   this->requestData(ToshibaCommandType::MODE);
   this->requestData(ToshibaCommandType::TARGET_TEMP);
   this->requestData(ToshibaCommandType::FAN);
@@ -137,6 +140,13 @@ void ToshibaClimateUart::getInitData() {
   this->requestData(ToshibaCommandType::ROOM_TEMP);
   this->requestData(ToshibaCommandType::OUTDOOR_TEMP);
   this->requestData(ToshibaCommandType::SPECIAL_MODE);
+}
+
+void ToshibaClimateUart::set_self_clean_running_(bool running) {
+  this->self_clean_running_ = running;
+  if (this->self_clean_sensor_ != nullptr) {
+    this->self_clean_sensor_->publish_state(running);
+  }
 }
 
 void ToshibaClimateUart::setup() {
@@ -285,7 +295,7 @@ void ToshibaClimateUart::parseResponse(std::vector<uint8_t> rawData) {
     case ToshibaCommandType::MODE: {
       auto mode = IntToClimateMode(static_cast<MODE>(value));
       ESP_LOGI(TAG, "Received AC mode: %s", climate_mode_to_string(mode));
-      if (this->power_state_ == STATE::ON) {
+      if (this->power_state_ == STATE::ON && !this->self_clean_running_) {
         this->mode = mode;
       }
       break;
@@ -317,11 +327,49 @@ void ToshibaClimateUart::parseResponse(std::vector<uint8_t> rawData) {
       if (climateState == STATE::OFF) {
         // AC unit was just powered off, set mode to OFF
         this->mode = climate::CLIMATE_MODE_OFF;
+        this->set_self_clean_running_(false);
+      } else if (this->self_clean_running_) {
+        if (this->self_clean_sensor_ != nullptr) {
+          ESP_LOGD(TAG, "Refreshing self-clean status after receiving AC ON state");
+          this->requestData(ToshibaCommandType::SELF_CLEAN);
+        }
       } else if (this->mode == climate::CLIMATE_MODE_OFF && climateState == STATE::ON) {
-        // AC unit was just powered on, query unit for it's MODE
+        // Unit reports ON while we believe it is off, e.g. powered on via IR
+        // remote, or the start of a post-shutdown self-clean cycle. When
+        // self-clean reporting is configured, query it first: the SELF_CLEAN
+        // response is processed before the MODE response below, so a running
+        // cycle keeps the entity OFF (the MODE response is ignored while
+        // self-clean is running).
+        if (this->self_clean_sensor_ != nullptr) {
+          this->requestData(ToshibaCommandType::SELF_CLEAN);
+        }
         this->requestData(ToshibaCommandType::MODE);
       }
       this->power_state_ = climateState;
+      break;
+    }
+    case ToshibaCommandType::SELF_CLEAN: {
+      auto self_clean_state = static_cast<SELF_CLEAN_STATE>(value);
+      bool was_running = this->self_clean_running_;
+      if (self_clean_state == SELF_CLEAN_STATE::RUNNING) {
+        ESP_LOGI(TAG, "Self-clean is running");
+        this->set_self_clean_running_(true);
+        this->mode = climate::CLIMATE_MODE_OFF;
+      } else if (self_clean_state == SELF_CLEAN_STATE::OFF) {
+        ESP_LOGI(TAG, "Self-clean is stopped");
+        this->set_self_clean_running_(false);
+        if (was_running) {
+          // The cycle ended: either it finished (unit now off) or it was
+          // interrupted by switching the unit back on. The self-clean register
+          // doesn't distinguish these, and the unit only reports power state on
+          // change/query (not continuously), so the cached value may be stale.
+          // Query the power state to resync; the POWER_STATE handler refreshes
+          // the mode when the unit turns out to be on.
+          this->requestData(ToshibaCommandType::POWER_STATE);
+        }
+      } else {
+        ESP_LOGW(TAG, "Received unknown self-clean state: %d", value);
+      }
       break;
     }
     case ToshibaCommandType::SPECIAL_MODE: {
@@ -422,6 +470,9 @@ void ToshibaClimateUart::dump_config() {
   if (vertical_air_direction_select_ != nullptr) {
     LOG_SELECT("", "Vertical air direction", this->vertical_air_direction_select_);
   }
+  if (self_clean_sensor_ != nullptr) {
+    LOG_BINARY_SENSOR("", "Self Clean", this->self_clean_sensor_);
+  }
   if (!supported_presets_.empty()) {
     ESP_LOGCONFIG(TAG, "Supported presets:");
     for (const char* &preset : supported_presets_) {
@@ -441,12 +492,18 @@ void ToshibaClimateUart::update() {
   if (outdoor_temp_sensor_ != nullptr) {
     this->requestData(ToshibaCommandType::OUTDOOR_TEMP);
   }
+  if (this->self_clean_running_) {
+    this->requestData(ToshibaCommandType::SELF_CLEAN);
+  }
 }
 
 void ToshibaClimateUart::control(const climate::ClimateCall &call) {
   if (call.get_mode().has_value()) {
     ClimateMode mode = *call.get_mode();
     ESP_LOGD(TAG, "Setting mode to %s", climate_mode_to_string(mode));
+    if (mode != CLIMATE_MODE_OFF) {
+      this->set_self_clean_running_(false);
+    }
     if (this->mode == CLIMATE_MODE_OFF && mode != CLIMATE_MODE_OFF) {
       ESP_LOGD(TAG, "Setting AC unit power state to ON.");
       this->sendCmd(ToshibaCommandType::POWER_STATE, static_cast<uint8_t>(STATE::ON));

--- a/components/toshiba_suzumi/toshiba_climate.h
+++ b/components/toshiba_suzumi/toshiba_climate.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/sensor/sensor.h"
@@ -61,6 +62,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void set_vertical_air_direction_select(select::Select *vertical_air_direction_select) {
     vertical_air_direction_select_ = vertical_air_direction_select;
   }
+  void set_self_clean_sensor(binary_sensor::BinarySensor *self_clean_sensor) { self_clean_sensor_ = self_clean_sensor; }
   void set_horizontal_swing(bool enabled) { horizontal_swing_ = enabled; }
   void disable_heat_mode(bool disabled) { heat_mode_disabled_ = disabled; }
   void disable_wifi_led(bool disabled) { wifi_led_disabled_ = disabled; }
@@ -80,9 +82,12 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   uint32_t last_command_timestamp_ = 0;
   uint32_t last_rx_char_timestamp_ = 0;
   STATE power_state_ = STATE::OFF;
+  // True while the unit is running its post-shutdown self-cleaning cycle.
+  bool self_clean_running_ = false;
   optional<SPECIAL_MODE> special_mode_ = SPECIAL_MODE::STANDARD;
   select::Select *pwr_select_ = nullptr;
   select::Select *vertical_air_direction_select_ = nullptr;
+  binary_sensor::BinarySensor *self_clean_sensor_ = nullptr;
   sensor::Sensor *indoor_temp_sensor_ = nullptr;
   sensor::Sensor *outdoor_temp_sensor_ = nullptr;
   sensor::Sensor *cdu_td_temp_sensor_ = nullptr;
@@ -109,6 +114,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void getInitData();
   void handle_rx_byte_(uint8_t c);
   bool validate_message_();
+  void set_self_clean_running_(bool running);
   void on_set_pwr_level(const std::string &value);
   void on_set_vertical_air_direction(const std::string &value);
   void publish_vertical_air_direction_(SWING swing_mode);

--- a/components/toshiba_suzumi/toshiba_climate_mode.h
+++ b/components/toshiba_suzumi/toshiba_climate_mode.h
@@ -52,6 +52,8 @@ enum class SWING {
 };
 enum class STATE { ON = 48, OFF = 49 };
 enum class PWR_LEVEL { PCT_50 = 50, PCT_75 = 75, PCT_100 = 100 };
+// Values documented by maxmacstn/ToshibaCarrierController.
+enum class SELF_CLEAN_STATE : uint8_t { RUNNING = 0x18, OFF = 0x10 };
 
 enum SPECIAL_MODE {
   STANDARD = 0,
@@ -81,6 +83,7 @@ enum class ToshibaCommandType : uint8_t {
   OUTDOOR_TEMP = 190,
   WIFI_LED_1 = 222,
   WIFI_LED_2 = 223,
+  SELF_CLEAN = 0xCB,
   SPECIAL_MODE = 247,
   IDU_STATUS = 0xE4,   // 228 - Indoor unit status (unsolicited)
   ODU_STATUS = 0xE5,   // 229 - Outdoor unit status (unsolicited)

--- a/example.yaml
+++ b/example.yaml
@@ -37,6 +37,8 @@ climate:
     #vertical_air_direction: # Optional. Fixed vertical air direction.
       # Controls the Toshiba horizontal louver, which directs air up/down.
       #name: "Vertical air direction"
+    #self_clean:              # Optional. Reports the post-shutdown self-cleaning cycle.
+      #name: "Self Clean"
     #horizontal_swing: true # Optional. Uncomment if your HVAC supports also horizontal swing
     #supported_presets:          # Optional. Enable only the features your HVAC
       #- "Standard"

--- a/example_esp8266.yaml
+++ b/example_esp8266.yaml
@@ -34,6 +34,8 @@ climate:
     #vertical_air_direction: # Optional. Fixed vertical air direction.
       # Controls the Toshiba horizontal louver, which directs air up/down.
       #name: "Vertical air direction"
+    #self_clean:              # Optional. Reports the post-shutdown self-cleaning cycle.
+      #name: "Self Clean"
     #horizontal_swing: true # Optional. Uncomment if your HVAC supports also horizontal swing
     #supported_presets:          # Optional. Enable only the features your HVAC
       #- "Standard"


### PR DESCRIPTION
## Summary
Adds an optional `self_clean` binary sensor that reports the Toshiba
post-shutdown self-cleaning cycle, and makes the climate entity represent
that state correctly — it stays OFF while the unit is self-cleaning instead
of showing a stale mode.

## Motivation
Many Toshiba/Carrier indoor units run a post-shutdown self-cleaning
("coil dry") cycle: after a cooling or dry run, turning the unit off keeps
the indoor fan running for ~30 min to dry the evaporator. During this cycle
the unit reports power-state = ON while the compressor is off and its
"operation" indicator is off.

Because this component derives the climate mode from the power-state
register, that ON is otherwise treated as a normal power-on, so the entity
shows the unit running in its last mode (e.g. COOL) for the entire ~30 min
cycle — even though the user turned it off. This PR makes the entity stay
OFF during the cycle and optionally exposes the cycle as a binary sensor.

You may not have a unit that runs this cycle; it's opt-in and designed for
no impact otherwise — see Compatibility.

## What it does
- New optional `self_clean` binary_sensor (`device_class: running`).
- Reads the self-clean status register `0xCB` (`0x18` = running,
  `0x10` = stopped; register values from maxmacstn/ToshibaCarrierController,
  behavior cross-checked against the Toshiba service manual §14).
- While self-cleaning the climate entity stays OFF and the sensor reads ON.
- Detects the cycle ending (polls the register while running; also handles
  unsolicited reports) and re-syncs power/mode, so the entity correctly
  follows the unit if it's turned back on during or after the cycle.

## Compatibility
- With `self_clean` not configured, the component never queries the
  self-clean register; units that don't report it behave exactly as before.
- Note: on units that broadcast `0xCB` unsolicited, the entity will reflect
  OFF during the cycle even without the sensor configured (more correct than
  the prior stale-mode behavior).

## Testing
Validated on a Toshiba Seiya indoor unit:
- Self-clean detected on power-off: sensor ON, climate OFF.
- Full untouched cycle ran ~30 min (matching the manual's fixed 30-min
  spec) and the entity returned to OFF; the unit reported power = OFF at
  completion.
- Turning the unit back on during/after the cycle (both via Home Assistant
  and the IR remote) correctly returns the entity to the active mode.
- No regression to normal mode/power control with the feature unconfigured.
