### PR TITLE
Update toshiba_climate.cpp

### DIFF
--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -293,12 +293,12 @@ void ToshibaClimateUart::parseResponse(std::vector<uint8_t> rawData) {
     case ToshibaCommandType::ROOM_TEMP:
       ESP_LOGI(TAG, "Received room temp: %d °C", value);
       this->current_temperature = value;
-      if (indoor_temp_sensor_ != nullptr) {
+      if (indoor_temp_sensor_ != nullptr && value != 127) {
         indoor_temp_sensor_->publish_state((int8_t) value);
       }
       break;
     case ToshibaCommandType::OUTDOOR_TEMP:
-      if (outdoor_temp_sensor_ != nullptr) {
+      if (outdoor_temp_sensor_ != nullptr && value != 127) {
         ESP_LOGI(TAG, "Received outdoor temp: %d °C", (int8_t) value);
         outdoor_temp_sensor_->publish_state((int8_t) value);
       }


### PR DESCRIPTION
Toshiba units report 127 when no temperature sensor is connected, so this invalid value should not be passed through as current_temperature.