### PR TITLE
Add min temp for different climate mode

### DIFF
--- a/components/toshiba_suzumi/climate.py
+++ b/components/toshiba_suzumi/climate.py
@@ -40,6 +40,8 @@ CONF_SELF_CLEAN = "self_clean"
 
 FEATURE_HORIZONTAL_SWING = "horizontal_swing"
 MIN_TEMP = "min_temp"
+MIN_TEMP_COOL = "min_temp_cool"
+MIN_TEMP_HEAT = "min_temp_heat"
 DISABLE_HEAT_MODE = "disable_heat_mode"
 DISABLE_WIFI_LED = "disable_wifi_led"
 
@@ -130,6 +132,8 @@ CONFIG_SCHEMA = climate.climate_schema(ToshibaClimateUart).extend(
         }),
         cv.Optional(CONF_SUPPORTED_PRESETS): cv.ensure_list(cv.one_of("Standard","Hi POWER","ECO","Fireplace 1","Fireplace 2","8 degrees","Silent#1","Silent#2","Sleep","Floor","Comfort")),
         cv.Optional(MIN_TEMP): cv.int_,
+        cv.Optional(MIN_TEMP_COOL): cv.int_,
+        cv.Optional(MIN_TEMP_HEAT): cv.int_,
     }
 ).extend(uart.UART_DEVICE_SCHEMA).extend(cv.polling_component_schema("120s"))
 
@@ -199,6 +203,10 @@ async def to_code(config):
 
     if MIN_TEMP in config:
         cg.add(var.set_min_temp(config[MIN_TEMP]))
+    if MIN_TEMP_COOL in config:
+        cg.add(var.set_min_temp_cool(config[MIN_TEMP_COOL]))
+    if MIN_TEMP_HEAT in config:
+        cg.add(var.set_min_temp_heat(config[MIN_TEMP_HEAT]))
 
     if DISABLE_HEAT_MODE in config:
         cg.add(var.disable_heat_mode(True))

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -556,6 +556,7 @@ void ToshibaClimateUart::control(const climate::ClimateCall &call) {
       this->target_temperature = effective_min;
       this->publish_state();
     }
+    this->publish_state();
     // === FIN LIMITES PAR MODE ===
   }
 

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -542,6 +542,18 @@ void ToshibaClimateUart::control(const climate::ClimateCall &call) {
       this->sendCmd(ToshibaCommandType::MODE, static_cast<uint8_t>(requestedMode));
     }
     this->mode = mode;
+    // === AJOUT POUR LIMITES PAR MODE ===
+    // Clamp target temperature to mode-specific minimum
+    float effective_min = this->min_temp_;
+    if (this->mode == climate::CLIMATE_MODE_COOL || this->mode == climate::CLIMATE_MODE_DRY) {
+      effective_min = this->min_temp_cool_;
+    } else if (this->mode == climate::CLIMATE_MODE_HEAT || this->mode == climate::CLIMATE_MODE_HEAT_COOL) {
+      effective_min = this->min_temp_heat_;
+    }
+    if (this->target_temperature < effective_min) {
+      this->target_temperature = effective_min;
+      this->publish_state();  // Rafraîchit l'interface Home Assistant
+    }
   }
 
   if (call.get_target_temperature().has_value()) {
@@ -707,8 +719,20 @@ ClimateTraits ToshibaClimateUart::traits() {
   traits.add_supported_fan_mode(CLIMATE_FAN_MEDIUM);
   traits.add_supported_fan_mode(CLIMATE_FAN_HIGH);
 
+  //traits.set_visual_temperature_step(1);
+  //traits.set_visual_min_temperature(this->min_temp_);
+  //traits.set_visual_max_temperature(MAX_TEMP);
+
   traits.set_visual_temperature_step(1);
-  traits.set_visual_min_temperature(this->min_temp_);
+
+// Mode-dependent visual min temperature for Home Assistant UI
+  float visual_min = this->min_temp_;
+  if (this->mode == climate::CLIMATE_MODE_COOL || this->mode == climate::CLIMATE_MODE_DRY) {
+    visual_min = this->min_temp_cool_;
+  } else if (this->mode == climate::CLIMATE_MODE_HEAT || this->mode == climate::CLIMATE_MODE_HEAT_COOL) {
+    visual_min = this->min_temp_heat_;
+  }
+  traits.set_visual_min_temperature(visual_min);
   traits.set_visual_max_temperature(MAX_TEMP);
 
   // Add supported standard presets based on configuration (custom presets are set in setup())

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -542,22 +542,35 @@ void ToshibaClimateUart::control(const climate::ClimateCall &call) {
       this->sendCmd(ToshibaCommandType::MODE, static_cast<uint8_t>(requestedMode));
     }
     this->mode = mode;
-    // === AJOUT POUR LIMITES PAR MODE ===
-    // Clamp target temperature to mode-specific minimum
+
+    // === LIMITES PAR MODE (Cool vs Heat) ===
     float effective_min = this->min_temp_;
     if (this->mode == climate::CLIMATE_MODE_COOL || this->mode == climate::CLIMATE_MODE_DRY) {
       effective_min = this->min_temp_cool_;
     } else if (this->mode == climate::CLIMATE_MODE_HEAT || this->mode == climate::CLIMATE_MODE_HEAT_COOL) {
       effective_min = this->min_temp_heat_;
     }
+
+    // Clamp si la température actuelle est trop basse pour le nouveau mode
     if (this->target_temperature < effective_min) {
       this->target_temperature = effective_min;
-      this->publish_state();  // Rafraîchit l'interface Home Assistant
+      this->publish_state();
     }
+    // === FIN LIMITES PAR MODE ===
   }
 
   if (call.get_target_temperature().has_value()) {
     auto target_temp = *call.get_target_temperature();
+    // Clamp selon le mode actuel
+    float effective_min = this->min_temp_;
+    if (this->mode == climate::CLIMATE_MODE_COOL || this->mode == climate::CLIMATE_MODE_DRY) {
+      effective_min = this->min_temp_cool_;
+    } else if (this->mode == climate::CLIMATE_MODE_HEAT || this->mode == climate::CLIMATE_MODE_HEAT_COOL) {
+      effective_min = this->min_temp_heat_;
+    }
+    if (target_temp < effective_min) {
+      target_temp = effective_min;
+    }
     uint8_t newTargetTemp = (uint8_t) target_temp;
     bool special_mode_changed = false;
     if (newTargetTemp >= MIN_TEMP_STANDARD && this->special_mode_ == SPECIAL_MODE::EIGHT_DEG) {

--- a/components/toshiba_suzumi/toshiba_climate.h
+++ b/components/toshiba_suzumi/toshiba_climate.h
@@ -16,6 +16,9 @@ static const char *const TAG = "ToshibaClimateUart";
 static const uint8_t MAX_TEMP = 30;
 // default min temp for units without 8° heating mode
 static const uint8_t MIN_TEMP_STANDARD = 17;
+// Default per-mode temperature limits
+static const uint8_t DEFAULT_MIN_TEMP_COOL = 17;
+static const uint8_t DEFAULT_MIN_TEMP_HEAT = 7;
 static const uint8_t SPECIAL_TEMP_OFFSET = 16;
 static const uint8_t SPECIAL_MODE_EIGHT_DEG_MIN_TEMP = 5;
 static const uint8_t SPECIAL_MODE_EIGHT_DEG_MAX_TEMP = 13;
@@ -68,6 +71,8 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void disable_wifi_led(bool disabled) { wifi_led_disabled_ = disabled; }
   void set_supported_presets(const std::vector<const char *> &presets) { supported_presets_ = presets; }
   void set_min_temp(uint8_t min_temp) { min_temp_ = min_temp; }
+  void set_min_temp_cool(uint8_t t) { min_temp_cool_ = t; }
+  void set_min_temp_heat(uint8_t t) { min_temp_heat_ = t; }
 
  protected:
   /// Override control to change settings of the climate device.
@@ -100,6 +105,8 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   sensor::Sensor *fcu_fan_rpm_sensor_ = nullptr;
   bool horizontal_swing_ = false;
   uint8_t min_temp_ = 17; // default min temp for units without 8° heating mode
+  uint8_t min_temp_cool_ = DEFAULT_MIN_TEMP_COOL;
+  uint8_t min_temp_heat_ = DEFAULT_MIN_TEMP_HEAT;
   bool heat_mode_disabled_ = false;
   bool wifi_led_disabled_ = false;
   std::vector<const char*> supported_presets_;


### PR DESCRIPTION
Add possibilities to fix min temp for cool and heat.
This is only necessary for this with use 8 deg mode
I had the problem using Versatile Thermostat sending a to low cooling temp (16°) and the Indoor unit was stuck because it's below what it can do;
Please review my code, as I'm not a dev, I just want to help on your great work